### PR TITLE
Fixed call to delete_device (method name changed)

### DIFF
--- a/scripts/rm_all_assets_from_group.rb
+++ b/scripts/rm_all_assets_from_group.rb
@@ -46,7 +46,7 @@ Nexpose::AssetGroup.load(nsc, group_id).devices.each do |device|
   if @dry_run
     puts "#{device.address} [ID: #{device.id}] Site: #{device.site_id}"
   else
-    nsc.device_delete(device.id)
+    nsc.delete_device(device.id)
   end
 end
 


### PR DESCRIPTION
Fixed a call to delete_device method (nexpose-0.5.4.gem) which was generating this error:

rm_all_assets_from_group.rb:49:in `block in <main>': undefined method`device_delete' for #Nexpose::Connection:0x00000002da2328 (NoMethodError)
        from rm_all_assets_from_group.rb:45:in `each'
        from rm_all_assets_from_group.rb:45:in`<main>'
