### PR TITLE
Fixed VulnerabilityDetail.description and .solution.

### DIFF
--- a/lib/nexpose/vuln.rb
+++ b/lib/nexpose/vuln.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 module Nexpose
   module NexposeAPI
     include XMLUtils


### PR DESCRIPTION
Currently, VulnerabilityDetail.description and .solution are created by calling the .text method on their respective nodes.  This will not return sub-elements such as ContainerBlockElement, Paragraph, and others.  Instead, the code has been modified to call .to_s on the node, which will include all child elements.

NOTE:  I have not extensively tested this change.  It works for me in my application, but it would be wise to take a closer look at this.  I don't have time for more testing, but I figured it would be better to submit this change than just forget about it.
