### PR TITLE
An incorrect type when parsing JSON in the Asset class for initialization

### DIFF
--- a/lib/nexpose/filter.rb
+++ b/lib/nexpose/filter.rb
@@ -362,7 +362,7 @@ module Nexpose
       @vuln_count = json['vulnCount'].to_i
       @risk_score = json['riskScore'].to_f
       @site_id = json['siteID']
-      @last_scan = Time.at(json['lastScanDate'] / 1000)
+      @last_scan = Time.at(json['lastScanDate'].to_i / 1000)
     end
   end
 end


### PR DESCRIPTION
In the Assets class in the initialization, the JSON parsing required a to_i" so that the 'lastScanDate' as a string can be divided by 1000 without throwing a 'NoMethodError' for the forward slash on a string object.
