### PR TITLE
Add `Criteria#<<(criterion)` to stop repetition

### DIFF
--- a/lib/nexpose/filter.rb
+++ b/lib/nexpose/filter.rb
@@ -324,6 +324,10 @@ module Nexpose
         'searchCriteria' => to_json }
     end
 
+    def <<(criterion)
+      criteria << criterion
+    end
+
     def self.parse(json)
       ret = Criteria.new([], json['operator'])
       json['criteria'].each do |c|


### PR DESCRIPTION
> Prior to this change `Nexpose::DynamicAssetGroup#criteria` accessor was used to get the DAG's criteria, `Criteria#criteria` was then used to get the actual array following `Array#<<(criterion)` which would be used to add a new criterion. Producing the longer syntax `dag.criteria.criteria << my_new_criterion` vs. `my_dag.criteria << my_new_criterion`.
## Before

``` ruby
dag = Nexpose::DynamicAssetGroup.new('test123')
criterion = Nexpose::Criterion.new(Nexpose::Search::Field::OS, Nexpose::Search::Operator::CONTAINS, 'linux')
dag.criteria = Nexpose::Criteria.new

# We needlessly repeat criteria here
dag.criteria.criteria << criterion
```
## After

``` ruby
dag = Nexpose::DynamicAssetGroup.new('test123')
criterion = Nexpose::Criterion.new(Nexpose::Search::Field::OS, Nexpose::Search::Operator::CONTAINS, 'linux')
dag.criteria = Nexpose::Criteria.new

# This is more straight forward
dag.criteria << criterion
```
