### PR TITLE
Add support for new Description tag in site and group configs

### DIFF
--- a/lib/nexpose/group.rb
+++ b/lib/nexpose/group.rb
@@ -99,7 +99,7 @@ module Nexpose
       xml.attributes['name'] = @name
       xml.attributes['description'] = @description
 
-      unless @description.empty?
+      if @description && !@description.empty?
         elem = REXML::Element.new('Description')
         elem.add_text(@description)
         xml.add_element(elem)

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -337,7 +337,7 @@ module Nexpose
       xml.attributes['riskfactor'] = @risk_factor
       xml.attributes['isDynamic'] == '1' if dynamic?
 
-      unless @description.empty?
+      if @description && !@description.empty?
         elem = REXML::Element.new('Description')
         elem.add_text(@description)
         xml.add_element(elem)


### PR DESCRIPTION
This is needed to support site and group descriptions with newline characters in an upcoming Nexpose release. This change should be backwards-compatible, though, and can probably be merged in at any time. The `<Description>` tag is ignored by current Nexpose versions and is optional for future versions.
