### PR TITLE
include engine scope attribute in list_engines

### DIFF
--- a/lib/nexpose/engine.rb
+++ b/lib/nexpose/engine.rb
@@ -47,7 +47,8 @@ module Nexpose
                                    engine.attributes['name'],
                                    engine.attributes['address'],
                                    engine.attributes['port'].to_i,
-                                   engine.attributes['status'])
+                                   engine.attributes['status'],
+                                   engine.attributes['scope'])
         end
       end
       arr


### PR DESCRIPTION
Previously this defaulted all engines to "silo" scope due to the default on initialize

Fixes #76 
