### PR TITLE
Use the #id reader instead of the nil @id variable

### DIFF
--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -423,7 +423,7 @@ module Nexpose
     # @param [Connection] nsc API connection to a Nexpose console.
     #
     def delete(nsc)
-      nsc.delete_scan_template(@id)
+      nsc.delete_scan_template(id)
     end
   end
 end


### PR DESCRIPTION
When template ID argument finally made it to url encoding when `String#gsub` was called on `@id` the variable would be nil. This change uses the id getter method instead of the absent `@id` instance variable (`ScanTemplate` never sets it while `ScanTemplateSummary` does).
