### PR TITLE
Remove unused "require 'nokogiri'"

### DIFF
--- a/lib/nexpose.rb
+++ b/lib/nexpose.rb
@@ -50,7 +50,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 require 'date'
 require 'time'
 require 'rexml/document'
-require 'nokogiri'
 require 'net/https'
 require 'net/http'
 require 'uri'


### PR DESCRIPTION
After removing Nokogiri as a dependency (see #97 and 042c2a3a68)
requiring Nexpose fails without nokogiri installed.

To reproduce this issue you can use this minimalistic Gemfile:
```ruby
source 'https://rubygems.org'

gem 'nexpose'
```

Using the `bundle exec` command you can exclude any gems not specified
in your Gemfile from your environment:
```
aus-mac-1033 @ ~/g/r/nexpose-polling λ bundle exec ruby -e "require 'nexpose'"
/Users/ecarey/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/nexpose-0.9.3/lib/nexpose.rb:53:in `require': cannot load such file -- nokogiri (LoadError)
        from /Users/ecarey/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/nexpose-0.9.3/lib/nexpose.rb:53:in `<top (required)>'
        from -e:1:in `require'
        from -e:1:in `<main>'
```