### PR TITLE
Wait update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Metrics/LineLength:
+  Max: 120

--- a/lib/nexpose.rb
+++ b/lib/nexpose.rb
@@ -100,6 +100,7 @@ require 'nexpose/vuln_exception'
 require 'nexpose/connection'
 require 'nexpose/maint'
 require 'nexpose/version'
+require 'nexpose/wait'
 
 module Nexpose
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -47,7 +47,7 @@ module Nexpose
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Integration Status of '#{status}' - Scan ID: #{scan_id}"
       rescue Nexpose::APIError => error
-        @error_message = "Error Waiting for Integration Scan ID: #{scan_id} :: #{error.req.error}"
+        @error_message = "API Error Waiting for Integration Scan ID: #{scan_id} :: #{error.req.error}"
       end
     end
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module Nexpose
 
   class Wait
@@ -28,6 +30,10 @@ module Nexpose
       rescue TimeoutError
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Report to Generate - Report Config ID: #{report_id}"
+      rescue NoMethodError => error
+        @error_message = "Error Report Config ID: #{report_id} :: Report Probably Does Not Exist :: #{error}"
+      rescue => error
+        @error_message = "Error Report Config ID: #{report_id} :: #{error}"
       end
     end
 
@@ -40,6 +46,8 @@ module Nexpose
       rescue TimeoutError
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Integration Status of '#{status}' - Scan ID: #{scan_id}"
+      rescue Nexpose::APIError => error
+        @error_message = "Error Waiting for Integration Scan ID: #{scan_id} :: #{error.req.error}"
       end
     end
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -102,10 +102,10 @@ module Nexpose
     end
 
 
-    def wait(cond)
+    def wait(condition)
       @poll_begin = Time.now
       loop do
-        break if cond.call
+        break if condition.call
         raise TimeoutError if @poll_begin + @timeout < Time.now
         sleep @polling_interval
       end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -7,7 +7,7 @@ module Nexpose
     def initialize(retry_count: nil, timeout: nil, polling_interval: nil)
       @error_message = "Default General Failure in Nexpose::Wait"
       @ready = false
-      @retry_count = retry_count.nil? ? 0 : retry_count
+      @retry_count = retry_count.to_i
       @timeout = timeout
       @polling_interval = polling_interval
     end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -3,7 +3,6 @@ module Nexpose
   class Wait
     attr_reader :error_message, :ready, :retry_count, :timeout, :polling_interval
 
-
     def initialize(retry_count: nil, timeout: nil, polling_interval: nil)
       @error_message = "Default General Failure in Nexpose::Wait"
       @ready = false
@@ -12,11 +11,9 @@ module Nexpose
       @polling_interval = polling_interval
     end
 
-
     def ready?
       @ready
     end
-
 
     def for_report(nexpose_connection: nil, report_id: nil)
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
@@ -31,7 +28,6 @@ module Nexpose
         @error_message = "Error Report Config ID: #{report_id} :: #{error}"
     end
 
-
     def for_integration(nexpose_connection: nil, scan_id: nil, status: 'finished')
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
       poller.wait(integration_status_proc(nexpose_connection: nsc, scan_id: scan_id, status: status))
@@ -42,7 +38,6 @@ module Nexpose
       rescue Nexpose::APIError => error
         @error_message = "API Error Waiting for Integration Scan ID: #{scan_id} :: #{error.req.error}"
     end
-
 
     def for_judgment(proc: nil, desc: nil)
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
@@ -56,11 +51,9 @@ module Nexpose
 
     private
 
-
       def report_status_proc(nexpose_connection: nil, report_id: nil)
         Proc.new { nsc.last_report(report_id).status == 'Generated' }
       end
-
 
       def integration_status_proc(nexpose_connection: nil, scan_id: scan_id, status: status)
         Proc.new { nsc.scan_status(scan_id).downcase == status.downcase }
@@ -75,9 +68,7 @@ module Nexpose
         end
       end
 
-
   end
-
 
 
 
@@ -86,7 +77,6 @@ module Nexpose
     ## Stand alone object to handle waiting logic.
     attr_reader :timeout, :polling_interval, :poll_begin
 
-
     def initialize(timeout: nil, polling_interval: nil)
       global_timeout = set_global_timeout
       @timeout = timeout.nil? ? global_timeout : timeout
@@ -94,7 +84,6 @@ module Nexpose
       global_polling = set_polling_interval
       @polling_interval = polling_interval.nil? ? global_polling : polling_interval
     end
-
 
     def wait(condition)
       @poll_begin = Time.now
@@ -105,9 +94,6 @@ module Nexpose
       end
     end
 
-
-
-
     private
 
       def set_global_timeout
@@ -115,13 +101,11 @@ module Nexpose
         ENV['GLOBAL_TIMEOUT'].nil? ? default_timeout : ENV['GLOBAL_TIMEOUT']
       end
 
-
       def set_polling_interval
         default_polling = 1
         ENV['GLOBAL_POLLING_INTERVAL'].nil? ? default_polling : ENV['GLOBAL_POLLING_INTERVAL']
       end
 
   end
-
 
 end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -35,6 +35,7 @@ module Nexpose
 
     private
 
+      # Method which contains a proc that we want to evaluate to true.
       def get_report_status(nsc:, report_id:)
         Proc.new { nsc.last_report(report_id).status == 'Generated' }
       end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -19,7 +19,7 @@ module Nexpose
     # Note: Uses keyword arguments.
     # Default Timeout is 120 seconds.
     # Default Polling Interval is 1 second.
-    def for_report(nsc:, report_id:, timeout: nil, polling_interval: nil)
+    def for_report(nsc: nil, report_id: nil, timeout: nil, polling_interval: nil)
       begin
         poller = Nexpose::Poller.new(timeout: timeout, polling_interval: polling_interval)
         poller.wait(get_report_status(nsc: nsc, report_id: report_id))
@@ -30,7 +30,7 @@ module Nexpose
     end
 
 
-    def for_integration(nsc:, scan_id:, status: 'finished', timeout: nil, polling_interval: nil)
+    def for_integration(nsc: nil, scan_id: nil, status: 'finished', timeout: nil, polling_interval: nil)
       begin
         poller = Nexpose::Poller.new(timeout: timeout, polling_interval: polling_interval)
         poller.wait(get_integration_status(nsc: nsc, scan_id: scan_id, status: status))
@@ -45,12 +45,12 @@ module Nexpose
     private
 
       # Method which contains a proc that we want to evaluate to true.
-      def get_report_status(nsc:, report_id:)
+      def get_report_status(nsc: nil, report_id: nil)
         Proc.new { nsc.last_report(report_id).status == 'Generated' }
       end
 
 
-      def get_integration_status(nsc:, scan_id: scan_id, status: status)
+      def get_integration_status(nsc: nil, scan_id: scan_id, status: status)
         Proc.new { nsc.scan_status(scan_id).downcase == status.downcase }
       end
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -19,10 +19,9 @@ module Nexpose
 
 
     def for_report(nsc: nil, report_id: nil)
-      begin
-        poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-        poller.wait(get_report_status(nsc: nsc, report_id: report_id))
-        @ready = true
+      poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
+      poller.wait(get_report_status(nsc: nsc, report_id: report_id))
+      @ready = true
       rescue TimeoutError
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Report to Generate - Report Config ID: #{report_id}"
@@ -30,33 +29,28 @@ module Nexpose
         @error_message = "Error Report Config ID: #{report_id} :: Report Probably Does Not Exist :: #{error}"
       rescue => error
         @error_message = "Error Report Config ID: #{report_id} :: #{error}"
-      end
     end
 
 
     def for_integration(nsc: nil, scan_id: nil, status: 'finished')
-      begin
-        poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-        poller.wait(get_integration_status(nsc: nsc, scan_id: scan_id, status: status))
-        @ready = true
+      poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
+      poller.wait(get_integration_status(nsc: nsc, scan_id: scan_id, status: status))
+      @ready = true
       rescue TimeoutError
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Integration Status of '#{status}' - Scan ID: #{scan_id}"
       rescue Nexpose::APIError => error
         @error_message = "API Error Waiting for Integration Scan ID: #{scan_id} :: #{error.req.error}"
-      end
     end
 
 
     def for_judgment(proc: nil, desc: nil)
-      begin
-        poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-        poller.wait(proc)
-        @ready = true
+      poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
+      poller.wait(proc)
+      @ready = true
       rescue TimeoutError
         retry if timeout_retry?
         @error_message = "Timeout Waiting for Judgment to Judge. #{desc}"
-      end
     end
 
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -1,0 +1,85 @@
+module Nexpose
+
+  class Wait
+    ## Nexpose Universal Wait module.
+    attr_reader :error_message, :ready
+
+
+    def initialize
+      @error_message = "Default General Failure in Nexpose::Wait"
+      @ready = false
+    end
+
+    def is_ready?
+      @ready
+    end
+
+
+    def for_report(nsc:, report_id:, timeout: nil, polling_interval: nil)
+      begin
+        poller = Nexpose::Poller.new(timeout: timeout, polling_interval: polling_interval)
+        poller.wait(get_report_status(nsc: nsc, report_id: report_id))
+        @ready = true
+      rescue TimeoutError
+        @error_message = "Timeout Waiting for Report to Generate - Report Config ID: #{report_id}"
+      end
+    end
+
+
+
+
+
+    private
+
+      def get_report_status(nsc:, report_id:)
+        Proc.new { nsc.last_report(report_id).status == 'Generated' }
+      end
+
+  end
+
+
+
+
+
+  class Poller
+    ## Stand alone object to handle waiting logic.
+    attr_reader :timeout, :polling_interval, :poll_begin
+
+
+    def initialize(timeout: nil, polling_interval: nil)
+      global_timeout = set_global_timeout
+      @timeout = timeout.nil? ? global_timeout : timeout
+      global_polling = set_polling_interval
+      @polling_interval = polling_interval.nil? ? global_polling : polling_interval
+    end
+
+
+    def wait(cond)
+      @poll_begin = Time.now
+      loop do
+        break if cond.call
+        raise TimeoutError if @poll_begin + @timeout < Time.now
+        sleep @polling_interval
+      end
+    end
+
+
+
+
+    private
+
+      def set_global_timeout
+        default_timeout = 120
+        ENV['GLOBAL_TIMEOUT'].nil? ? default_timeout : ENV['GLOBAL_TIMEOUT']
+      end
+
+
+      def set_polling_interval
+        default_polling = 1
+        ENV['GLOBAL_POLLING_INTERVAL'].nil? ? default_polling : ENV['GLOBAL_POLLING_INTERVAL']
+      end
+
+  end
+
+
+end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -69,9 +69,9 @@ module Nexpose
       def timeout_retry?
         if @retry_count > 0
           @retry_count = @retry_count - 1
-          return true
+          true
         else
-          return false
+          false
         end
       end
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -13,14 +13,14 @@ module Nexpose
     end
 
 
-    def is_ready?
+    def ready?
       @ready
     end
 
 
-    def for_report(nsc: nil, report_id: nil)
+    def for_report(nexpose_connection: nil, report_id: nil)
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-      poller.wait(get_report_status(nsc: nsc, report_id: report_id))
+      poller.wait(report_status_proc(nexpose_connection: nsc, report_id: report_id))
       @ready = true
       rescue TimeoutError
         retry if timeout_retry?
@@ -32,9 +32,9 @@ module Nexpose
     end
 
 
-    def for_integration(nsc: nil, scan_id: nil, status: 'finished')
+    def for_integration(nexpose_connection: nil, scan_id: nil, status: 'finished')
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-      poller.wait(get_integration_status(nsc: nsc, scan_id: scan_id, status: status))
+      poller.wait(integration_status_proc(nexpose_connection: nsc, scan_id: scan_id, status: status))
       @ready = true
       rescue TimeoutError
         retry if timeout_retry?
@@ -57,12 +57,12 @@ module Nexpose
     private
 
 
-      def get_report_status(nsc: nil, report_id: nil)
+      def report_status_proc(nexpose_connection: nil, report_id: nil)
         Proc.new { nsc.last_report(report_id).status == 'Generated' }
       end
 
 
-      def get_integration_status(nsc: nil, scan_id: scan_id, status: status)
+      def integration_status_proc(nexpose_connection: nil, scan_id: scan_id, status: status)
         Proc.new { nsc.scan_status(scan_id).downcase == status.downcase }
       end
 

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -1,10 +1,9 @@
 module Nexpose
 
   class Wait
-    ## Nexpose Universal Wait module.
     attr_reader :error_message, :ready, :retry_count, :timeout, :polling_interval
 
-    # Setup Default error_message, set ready state to false, and allow caller to specify a retry count if there are Timeout failures.
+
     def initialize(retry_count: nil, timeout: nil, polling_interval: nil)
       @error_message = "Default General Failure in Nexpose::Wait"
       @ready = false
@@ -13,15 +12,12 @@ module Nexpose
       @polling_interval = polling_interval
     end
 
-    # Allow class to respond in a readable way to see if we are done waiting.
+
     def is_ready?
       @ready
     end
 
 
-    # Note: Uses keyword arguments.
-    # Default Timeout is 120 seconds.
-    # Default Polling Interval is 1 second.
     def for_report(nsc: nil, report_id: nil)
       begin
         poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
@@ -66,7 +62,7 @@ module Nexpose
 
     private
 
-      # Method which contains a proc that we want to evaluate to true.
+
       def get_report_status(nsc: nil, report_id: nil)
         Proc.new { nsc.last_report(report_id).status == 'Generated' }
       end

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -4,17 +4,19 @@ module Nexpose
     ## Nexpose Universal Wait module.
     attr_reader :error_message, :ready
 
-
+    # Setup Default error_message, and set ready state to false.
     def initialize
       @error_message = "Default General Failure in Nexpose::Wait"
       @ready = false
     end
 
+    # Allow class to respond in a readable way to see if we are done waiting.
     def is_ready?
       @ready
     end
 
 
+    # Note: Uses keyword arguments.
     def for_report(nsc:, report_id:, timeout: nil, polling_interval: nil)
       begin
         poller = Nexpose::Poller.new(timeout: timeout, polling_interval: polling_interval)

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -17,6 +17,8 @@ module Nexpose
 
 
     # Note: Uses keyword arguments.
+    # Default Timeout is 120 seconds.
+    # Default Polling Interval is 1 second.
     def for_report(nsc:, report_id:, timeout: nil, polling_interval: nil)
       begin
         poller = Nexpose::Poller.new(timeout: timeout, polling_interval: polling_interval)

--- a/lib/nexpose/wait.rb
+++ b/lib/nexpose/wait.rb
@@ -4,7 +4,7 @@ module Nexpose
     attr_reader :error_message, :ready, :retry_count, :timeout, :polling_interval
 
     def initialize(retry_count: nil, timeout: nil, polling_interval: nil)
-      @error_message = "Default General Failure in Nexpose::Wait"
+      @error_message = 'Default General Failure in Nexpose::Wait'
       @ready = false
       @retry_count = retry_count.to_i
       @timeout = timeout
@@ -17,7 +17,7 @@ module Nexpose
 
     def for_report(nexpose_connection: nil, report_id: nil)
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-      poller.wait(report_status_proc(nexpose_connection: nsc, report_id: report_id))
+      poller.wait(report_status_proc(nexpose_connection: nexpose_connection, report_id: report_id))
       @ready = true
       rescue TimeoutError
         retry if timeout_retry?
@@ -30,7 +30,7 @@ module Nexpose
 
     def for_integration(nexpose_connection: nil, scan_id: nil, status: 'finished')
       poller = Nexpose::Poller.new(timeout: @timeout, polling_interval: @polling_interval)
-      poller.wait(integration_status_proc(nexpose_connection: nsc, scan_id: scan_id, status: status))
+      poller.wait(integration_status_proc(nexpose_connection: nexpose_connection, scan_id: scan_id, status: status))
       @ready = true
       rescue TimeoutError
         retry if timeout_retry?
@@ -48,30 +48,25 @@ module Nexpose
         @error_message = "Timeout Waiting for Judgment to Judge. #{desc}"
     end
 
-
     private
 
       def report_status_proc(nexpose_connection: nil, report_id: nil)
-        Proc.new { nsc.last_report(report_id).status == 'Generated' }
+        Proc.new { nexpose_connection.last_report(report_id).status == 'Generated' }
       end
 
       def integration_status_proc(nexpose_connection: nil, scan_id: scan_id, status: status)
-        Proc.new { nsc.scan_status(scan_id).downcase == status.downcase }
+        Proc.new { nexpose_connection.scan_status(scan_id).downcase == status.downcase }
       end
 
       def timeout_retry?
         if @retry_count > 0
-          @retry_count = @retry_count - 1
+          @retry_count -= 1
           true
         else
           false
         end
       end
-
   end
-
-
-
 
   class Poller
     ## Stand alone object to handle waiting logic.
@@ -105,7 +100,5 @@ module Nexpose
         default_polling = 1
         ENV['GLOBAL_POLLING_INTERVAL'].nil? ? default_polling : ENV['GLOBAL_POLLING_INTERVAL']
       end
-
   end
-
 end


### PR DESCRIPTION
### Timeout Errors:
Currently using all of the wait methods, if the Timeout is reached, the error gets swallowed up by the surrounding code and errors do not get printed to the logs.

This causes the tests using these methods to continue with their test as if nothing bad has happened. 

Example:

	When /^the user configures a report on the asset while still in that state$/ do
	  config = Nexpose::ReportConfig.new("cucumber report-#{@site.id}.csv", NSC.get_csv_template(@console), 'csv')
	  config.add_filter('site', @site.id)
	  config.save(@console, true)
	  at_scenario_exit { @console.delete_report_config(config.id) }
	  NSC.wait_for_report(@console, config.id)
	  @tmp_report = NSC.download_report(@console, @site.id, config.id)
	end

In the above example, if the `wait_for_report` hits a timeout, the next line `download_report` executes as if everything is okay.


---

### Current Landscape:
 
#### wait_until (71)
scanning status and scan integration, as well as waiting on UI elements. 


#### wait_for_report (37)
generally only used when the next step is to download a CSV report, or verifying a report's status.


#### wait_for_integration (84)
used to wait for scan_status to become 'finished', or other passed in status. 


#### sleep (35)
mostly seems to be used to slow down the UI after click events. however, other instances are used instead of the above methods.


---


### Proposed Enhancements: 

The Nexpose-client gem can contain the following Wait object, to help deal with the Timeout concerns.

Currently [`Nexpose::Wait`](https://github.com/sgreen-r7/nexpose-client/blob/wait_update/lib/nexpose/wait.rb) has the following methods:
`for_report`
`for_integration`
`for_judgement`


`for_report` would replace `wait_for_report`  
`for_integration` would replace `wait_for_integration`  
`for_judgement` would _hopefully_ _mostly_ replace `wait_until`



So our example at the beginning for waiting on reports would look something like this now:

	When /^the user configures a report on the asset while still in that state$/ do
	 config = Nexpose::ReportConfig.new("cucumber report-#{@site.id}.csv", NSC.get_csv_template(@console), 'csv')
	 config.add_filter('site', @site.id)
	 config.save(@console, true)
	 at_scenario_exit { @console.delete_report_config(config.id) }

	 report_wait = Nexpose::Wait.new
	 report_wait.for_report( nexpose_connection: @console, report_id: config.id )
	 unless report_wait.ready?
	   expect(report_wait).to be_true, report_wait.error_message
	 end

	 @tmp_report = NSC.download_report(@console, @site.id, config.id)
	end


Or you could wrap `is_ready?` in an if block (shown with adjusting the timeout, and having it retry if it fails):

	When /^the user configures a report on the asset while still in that state$/ do
	 config = Nexpose::ReportConfig.new("cucumber report-#{@site.id}.csv", NSC.get_csv_template(@console), 'csv')
	 config.add_filter('site', @site.id)
	 config.save(@console, true)
	 at_scenario_exit { @console.delete_report_config(config.id) }

	 report_wait = Nexpose::Wait.new(timeout: 60, retry_count: 2)
	 report_wait.for_report( nexpose_connection: @console, report_id: config.id )
	 if report_wait.ready?
	 	@tmp_report = NSC.download_report(@console, @site.id, config.id)
	 else
	   expect(report_wait).to be_true, report_wait.error_message
	 end
	 
	end


---


### Nexpose::Wait.new

Calling a new `Nexpose::Wait` object will allow you to initialize with the following options, which uses Ruby keyword arguments:

`error_message`: Overwrite the default error message.  
`retry_count`: The number of times to retry the wait if we hit the timeout limit.  
`timeout`: Number of seconds before we consider the request timed out.  
`polling_interval`: Number of seconds to sleep before we retry to execute for the desired result.  

`Nexpose::Wait.new( retry_count: 3, timeout: 120, polling_interval: 1 )`



<dl>
  <dt>for_report</dt>
  <dd>pass in nsc connection, and report config id.</dd>

  <dt>for_integration</dt>
  <dd>pass in nsc connection, scan id, and status that you're looking for.</dd>
  
   <dt>for_judgement</dt>
  <dd>pass in a proc, and an optional description to display and output if an error or timeout occurs.</dd>
</dl>


All `for_` methods support outputting an error message for timeouts, and additionally support API errors, and NoMethodErrors if reports or scans don't exist. 

