### PR TITLE
Set @type in DiscoveryConnection.parse

### DIFF
--- a/lib/nexpose/discovery.rb
+++ b/lib/nexpose/discovery.rb
@@ -165,6 +165,7 @@ module Nexpose
       conn.protocol = xml.attributes['protocol']
       conn.port = xml.attributes['port'].to_i
       conn.status = xml.attributes['connection-status']
+      conn.type = xml.attributes['type']
       conn
     end
   end


### PR DESCRIPTION
I initially committed this directly to `master` (my bad!). When listing the `DiscoveryConnection`s previously type was not being set on `DiscoveryConnection.parse`.