### PR TITLE
have vcr ignore codeclimate as host

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ VCR.configure do |config|
   config.filter_sensitive_data('johndoe') { ENV['NEXPOSE_USERNAME'] }
   config.filter_sensitive_data('password123') { ENV['NEXPOSE_PASSWORD'] }
   config.hook_into :webmock
+  config.ignore_hosts 'codeclimate.com'
 end
 
 SimpleCov.start


### PR DESCRIPTION
Coverage report generated for RSpec to /home/travis/build/rapid7/nexpose-client/coverage. 2185 / 4782 LOC (45.69%) covered.
Coverage = 45.69%. Sending report to https://codeclimate.com for branch ruby_215_update... Code Climate encountered an exception: VCR::Errors::UnhandledHTTPRequestError


Hey! Looks like you are using VCR, which will prevent the codeclimate-test-reporter from reporting results to codeclimate.com.
Add the following to your spec or test helper to ensure codeclimate-test-reporter can post coverage results:
  VCR.configure do |config|
    # your existing configuration
    config.ignore_hosts 'codeclimate.com'
  end


If this doesn't work, please consult https://codeclimate.com/docs#test-coverage-troubleshooting