### PR TITLE
Update to rex v2.0.8

### DIFF
--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
   s.platform              = 'ruby'
 
-  s.add_runtime_dependency('rex', '~> 2.0.5', '>= 2.0.5')
+  s.add_runtime_dependency('rex', '~> 2.0', '>= 2.0.8')
 
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')


### PR DESCRIPTION
See https://github.com/rapid7/rex/issues/2 and the changes on the metasploit-framework "upstream" version of rex here https://github.com/rapid7/metasploit-framework/commit/ab4a41695.

- [x] Address the ruby 2.2.x duplicate key warnings.
- [x] Relax the version constraint of rex to "~> 2.0" vs. "~> 2.0.5".