### PR TITLE
Allow control of device discovery and other template options

### DIFF
--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -202,7 +202,6 @@ module Nexpose
     # @param [Array] ports to scan for device discovery
     def tcp_discovery_ports=(ports)
       tcp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/TCPHostCheck')
-      enable_tcp_discovery(true)
       REXML::XPath.first(tcp, './portList').text = ports.join(',')
     end
 
@@ -217,7 +216,6 @@ module Nexpose
     # @param [Array] posts to scan for UDP device discovery
     def udp_discovery_ports=(ports)
       udp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/UDPHostCheck')
-      enable_udp_discovery(true)
       REXML::XPath.first(udp, './portList').text = ports.join(',')
     end
 

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -178,7 +178,7 @@ module Nexpose
 
     # Enable/disable IP stack fingerprinting
     # @param [Boolean] enable or disable IP stack fingerprinting
-    def enable_ip_stack_fingerprinting(enable)
+    def enable_ip_stack_fingerprinting=(enable)
       ns = REXML::XPath.first(@xml, 'ScanTemplate/Plugins/Plugin[@name="java/NetworkScanners"]')
       param = REXML::XPath.first(ns, './param[@name="ipFingerprintEnabled"]')
       if param

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -176,6 +176,56 @@ module Nexpose
       host_threads.text = threads.to_s
     end
 
+    # Enable/disable IP stack fingerprinting
+    # @param [Boolean] enable or disable IP stack fingerprinting
+    def enable_ip_stack_fingerprinting(enable)
+      ns = REXML::XPath.first(@xml, 'ScanTemplate/Plugins/Plugin[@name="java/NetworkScanners"]')
+      param = REXML::XPath.first(ns, './param[@name="ipFingerprintEnabled"]')
+      unless param
+        param = REXML::Element.new('param')
+        param.add_attribute('name', 'ipFingerprintEnabled')
+        ns.add_element(param)
+      end
+      param.text = (enable ? 1 : 0)
+    end
+
+    # Enable/diisable ICMP device discovery
+    # @param [Boolean] enable or disable ICMP device discovery
+    def enable_icmp_discovery=(enable)
+      icmp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/icmpHostCheck')
+      icmp.attributes['enabled'] = (enable ? 1 : 0)
+    end
+
+    # Add custom TCP ports to scan for device discovery
+    # @param [Array] ports to scan for device discovery
+    def tcp_discovery_ports=(ports)
+      tcp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/TCPHostCheck')
+      enable_tcp_discovery = true
+      REXML::XPath.first(tcp, './portList').text = ports.join(",")
+    end
+
+    # Enable/disable TCP device discovery
+    # @param [Boolean] enable or disable TCP device discovery
+    def enable_tcp_discovery=(enable)
+      tcp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/TCPHostCheck')
+      tcp.attributes['enabled'] = (enable ? 1 : 0)
+    end
+
+    # Add custom UDP ports to scan for UDP device discovery
+    # @param [Array] posts to scan for UDP device discovery
+    def udp_discovery_ports=(ports)
+      udp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/UDPHostCheck')
+      enable_udp_discovery = true
+      REXML::XPath.first(udp, './portList').text = ports.join(",")
+    end
+
+    # Enable/diisable UDP device discovery
+    # @param [Boolean] enable or disable UDP device discovery
+    def enable_udp_discovery=(enable)
+      udp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/UDPHostCheck')
+      udp.attributes['enabled'] = (enable ? 1 : 0)
+    end
+
     # Add custom TCP ports to scan for services
     # @param [Array] ports to scan
     def tcp_service_ports=(ports)

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -181,12 +181,14 @@ module Nexpose
     def enable_ip_stack_fingerprinting(enable)
       ns = REXML::XPath.first(@xml, 'ScanTemplate/Plugins/Plugin[@name="java/NetworkScanners"]')
       param = REXML::XPath.first(ns, './param[@name="ipFingerprintEnabled"]')
-      unless param
+      if param
+        param.text = (enable ? 1 : 0)
+      else
         param = REXML::Element.new('param')
         param.add_attribute('name', 'ipFingerprintEnabled')
+        param.text = (enable ? 1 : 0)
         ns.add_element(param)
       end
-      param.text = (enable ? 1 : 0)
     end
 
     # Enable/diisable ICMP device discovery
@@ -200,8 +202,8 @@ module Nexpose
     # @param [Array] ports to scan for device discovery
     def tcp_discovery_ports=(ports)
       tcp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/TCPHostCheck')
-      enable_tcp_discovery = true
-      REXML::XPath.first(tcp, './portList').text = ports.join(",")
+      enable_tcp_discovery(true)
+      REXML::XPath.first(tcp, './portList').text = ports.join(',')
     end
 
     # Enable/disable TCP device discovery
@@ -215,8 +217,8 @@ module Nexpose
     # @param [Array] posts to scan for UDP device discovery
     def udp_discovery_ports=(ports)
       udp = REXML::XPath.first(@xml, 'ScanTemplate/DeviceDiscovery/CheckHosts/UDPHostCheck')
-      enable_udp_discovery = true
-      REXML::XPath.first(udp, './portList').text = ports.join(",")
+      enable_udp_discovery(true)
+      REXML::XPath.first(udp, './portList').text = ports.join(',')
     end
 
     # Enable/diisable UDP device discovery


### PR DESCRIPTION
This adds support for:
  * Enabling/disabling ICMP, TCP and UDP device discovery
 * Tweaking of ports used for TCP and UDP device (not service) discovery
 * Enabling/disabling of IP stack fingerprinting