### PR TITLE
Remove Ruby 1.9.3 support, require Ruby 2.1.5 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.1.5
   - 2.2.0
 script: bundle exec rspec --color --format=documentation
 addons:

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
   s.platform              = 'ruby'
 
-  s.add_runtime_dependency('rex', '~> 2.0.5', '>= 2.0.5')
+  s.add_runtime_dependency('rex', '~> 2.0.8', '>= 2.0.8')
 
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files                 = Dir['[A-Z]*'] + Dir['lib/**/*']
   s.require_paths         = ['lib']
   s.extra_rdoc_files      = ['README.markdown']
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.1'
   s.platform              = 'ruby'
 
   s.add_runtime_dependency('rex', '~> 2.0.5', '>= 2.0.5')

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
   s.platform              = 'ruby'
 
-  s.add_runtime_dependency('rex', '~> 2.0.8', '>= 2.0.8')
+  s.add_runtime_dependency('rex', '~> 2.0', '>= 2.0.8')
 
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')


### PR DESCRIPTION
This is prep for the upcoming 1.0 release

Resolves #95 

Removes Ruby 1.9.3 and 2.0.0 from Travis
Requires Ruby 2.1.5 as minimum version to use Nexpose gem
Bump Rex min version to 2.0.8 for a Ruby 2.2-specific fix on warnings