### PR TITLE
site-api/site: collapse include_asset methods and add deprecrated methods

### DIFF
--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -176,56 +176,6 @@ module Nexpose
       !@discovery_config.nil?
     end
 
-    # Adds an asset to this site by host name.
-    #
-    # @param [String|HostName] hostname FQDN or DNS-resolvable host name of an asset.
-    def include_host(hostname)
-      hostname = HostName.new(hostname) if hostname.is_a? String
-      raise 'Invalid hostname specified' unless hostname.is_a? HostName
-      @included_scan_targets[:addresses] << hostname
-    end
-
-    # Remove an asset to this site by host name.
-    #
-    # @param [String|HostName] hostname FQDN or DNS-resolvable host name of an asset.
-    def remove_included_host(hostname)
-      hostname = HostName.new(hostname) if hostname.is_a? String
-      raise 'Invalid hostname specified' unless hostname.is_a? HostName
-      @included_scan_targets[:addresses].reject! { |t| t.eql? hostname }
-    end
-
-    # Adds an asset to this site by IP address.
-    #
-    # @param [String|IPRange] ip IP address of an asset.
-    def include_ip(ip)
-      begin
-        if ip.is_a? String
-          IPAddr.new(ip)
-          ip = IPRange.new(ip)
-        end
-        raise 'Invalid IP address specified' unless ip.is_a? IPRange
-        @included_scan_targets[:addresses] << ip
-      rescue ArgumentError => e
-        raise e.message
-      end
-    end
-
-    # Remove an asset to this site by IP address.
-    #
-    # @param [String|IPRange] ip IP address of an asset.
-    def remove_included_ip(ip)
-      begin
-        if ip.is_a? String
-          IPAddr.new(ip)
-          ip = IPRange.new(ip)
-        end
-        raise 'Invalid IP address specified' unless ip.is_a? IPRange
-        @included_scan_targets[:addresses].reject! { |t| t.eql? ip }
-      rescue ArgumentError => e
-        raise e.message
-      end
-    end
-
     # Adds assets to this site by IP address range.
     #
     # @param [String] from Beginning IP address of a range.
@@ -242,6 +192,12 @@ module Nexpose
       rescue ArgumentError => e
         raise "#{e.message} in given IP range"
       end
+    end
+
+    # @deprecated Use {#include_ip_range} instead.
+    def add_ip_range(from, to)
+      warn "[DEPRECATED] Use #{self.class}#include_ip_range instead of #{self.class}#add_ip_range."
+      include_ip_range(from, to)
     end
 
     # Remove assets to this site by IP address range.
@@ -262,6 +218,12 @@ module Nexpose
       end
     end
 
+    # @deprecated Use {#remove_included_ip_range} instead.
+    def remove_ip_range(from, to)
+      warn "[DEPRECATED] Use #{self.class}#remove_included_ip_range instead of #{self.class}#remove_ip_range."
+      remove_included_ip_range(from, to)
+    end
+
     # Adds an asset to this site included scan targets, resolving whether an IP or hostname is
     # provided.
     #
@@ -270,6 +232,15 @@ module Nexpose
     def include_asset(asset)
       @included_scan_targets[:addresses] << HostOrIP.convert(asset)
     end
+
+    # @deprecated Use {#include_asset} instead.
+    def add_asset(asset)
+      warn "[DEPRECATED] Use #{self.class}#include_asset instead of #{self.class}#add_asset."
+      include_asset(asset)
+    end
+
+    alias_method :add_host, :add_asset
+    alias_method :add_ip, :add_asset
 
     # Remove an asset to this site included scan targets, resolving whether an IP or hostname is
     # provided.
@@ -280,55 +251,14 @@ module Nexpose
       @included_scan_targets[:addresses].reject! { |existing_asset| existing_asset == HostOrIP.convert(asset) }
     end
 
-    # Adds an asset to this site excluded scan targets by host name.
-    #
-    # @param [String|HostName] hostname FQDN or DNS-resolvable host name of an asset.
-    def exclude_host(hostname)
-      hostname = HostName.new(hostname) if hostname.is_a? String
-      raise 'Invalid hostname specified' unless hostname.is_a? HostName
-      @excluded_scan_targets[:addresses] << hostname
+    # @deprecated Use {#remove_included_asset} instead.
+    def remove_asset(asset)
+      warn "[DEPRECATED] Use #{self.class}#remove_included_asset instead of #{self.class}#remove_asset."
+      remove_included_asset(asset)
     end
 
-    # Remove an asset from this site excluded scan targets by host name.
-    #
-    # @param [String|HostName] hostname FQDN or DNS-resolvable host name of an asset.
-    def remove_excluded_host(hostname)
-      hostname = HostName.new(hostname) if hostname.is_a? String
-      raise 'Invalid hostname specified' unless hostname.is_a? HostName
-      @excluded_scan_targets[:addresses].reject! { |t| t.eql? hostname }
-    end
-
-    # Adds an asset to this site excluded scan targets by IP address.
-    #
-    # @param [String|IPRange] ip IP address of an asset.
-    def exclude_ip(ip)
-      begin
-        if ip.is_a? String
-          IPAddr.new(ip)
-          ip = IPRange.new(ip)
-        end
-        raise 'Invalid IP address specified' unless ip.is_a? IPRange
-        @excluded_scan_targets[:addresses] << ip
-      rescue ArgumentError => e
-        raise e.message
-      end
-    end
-
-    # Remove an asset from this site excluded scan targets by IP address.
-    #
-    # @param [String|IPRange] ip IP address of an asset.
-    def remove_excluded_ip(ip)
-      begin
-        if ip.is_a? String
-          IPAddr.new(ip)
-          ip = IPRange.new(ip)
-        end
-        raise 'Invalid IP address specified' unless ip.is_a? IPRange
-        @excluded_scan_targets[:addresses].reject! { |t| t.eql? ip }
-      rescue ArgumentError => e
-        raise e.message
-      end
-    end
+    alias_method :remove_host, :remove_asset
+    alias_method :remove_ip, :remove_asset
 
     # Adds assets to this site excluded scan targets by IP address range.
     #


### PR DESCRIPTION
Collapse `include_*` methods and add deprecated methods
Allows some backwards compatibility with pre-1.0 versions, but warns about deprecation.

We can remove the deprecated methods in 1.1.0 or something.