### PR TITLE
Send the engine-id when calling DiscoveryConnection#save

### DIFF
--- a/lib/nexpose/discovery.rb
+++ b/lib/nexpose/discovery.rb
@@ -55,6 +55,9 @@ module Nexpose
     # The IP address or fully qualified domain name of the server.
     attr_accessor :address
 
+    # The engine ID to use for this connection.
+    attr_accessor :engine_id
+
     # A user name that can be used to log into the server.
     attr_accessor :user
 
@@ -150,6 +153,7 @@ module Nexpose
       xml.attributes['user-name'] = @user
       xml.attributes['password']  = @password
       xml.attributes['type']      = @type if @type
+      xml.attributes['engine-id'] = @engine_id if @engine_id && @engine_id != -1
       xml
     end
 


### PR DESCRIPTION
One of the upcoming releases will add a discovery connection type that supports sending `engine-id` as a parameter. This unblocks @rtaylor-r7 who got bit by a monkey patched `DiscoveryConnection#as_xml` method when he was adding different parameters from another new discovery connection type.

cc: @rtaylor-r7 @gschneider-r7 @sgreen-r7 