### PR TITLE
Merge master into site-api branch

### DIFF
--- a/.pullreview.yml
+++ b/.pullreview.yml
@@ -1,0 +1,4 @@
+---
+notifications:
+  pullrequest:
+    comment: verbose

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Metrics/LineLength:
+  Max: 120

--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,9 @@ Check out https://github.com/rapid7/nexpose-client/wiki for walk-throughs and re
 
 This gem is heavily used for internal, automated testing of the Nexpose product. It provides calls to the Nexpose XML APIs version 1.1 and 1.2 (except for some multi-tenant operations). It also includes a number of helper methods which are not currently exposed through alternate means.
 
+## Release Notes
+
+Release notes are available on the [Releases](https://github.com/rapid7/nexpose-client/releases) page.
 
 ## Contributions
 

--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '0.9.8'
+  VERSION = '0.9.9'
 end

--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '0.9.7'
+  VERSION = '0.9.8'
 end

--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '0.9.6'
+  VERSION = '0.9.7'
 end

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
   s.platform              = 'ruby'
 
-  s.add_runtime_dependency('rex', '~> 2.0.5', '>= 2.0.5')
+  s.add_runtime_dependency('rex', '2.0.7')
 
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')


### PR DESCRIPTION
The new methods in scan_template.rb are currently used in automation, but are not available on the site-api branch. This merge will allow us to leverage the new scan template port enhancements. 