### PR TITLE
Remove asset from range

### DIFF
--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -178,6 +178,19 @@ module Nexpose
       @discovery_connection_id = value.to_i
     end
 
+    def include_asset?(asset)
+      include_hostname?(asset) || include_ip_range?(asset)
+    end
+
+    def include_hostname?(host)
+      host = HostName.new(host) unless host.is_a?(HostName)
+      assets.grep(HostName) { |asset| asset.eql?(host) }.any?
+    end
+
+    def include_ip_range?(range)
+      assets.grep(IPRange) { |asset| asset.include?(range) }.any?
+    end
+
     # Adds an asset to this site by host name.
     #
     # @param [String] hostname FQDN or DNS-resolvable host name of an asset.

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -729,7 +729,9 @@ module Nexpose
       to = @to.nil? ? from : IPAddr.new(@to)
       other = IPAddr.new(single_ip)
 
-      if other < from
+      if other == from || other == to
+        true
+      elsif other < from
         false
       elsif to < other
         false

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -218,11 +218,13 @@ module Nexpose
     def remove_ip(ip)
       ip = IPRange.new(ip)
       @assets.each do |asset_range|
-        next unless asset_range.include?(ip)
-        asset = split_ip_range(asset_range, ip)
-        @assets.delete(asset_range)
-        @assets.push(asset)
-        @assets.flatten!
+        return if asset_range.is_a?(Nexpose::HostName)
+        if asset_range.include?(ip)
+          asset = split_ip_range(asset_range, ip)
+          @assets.delete(asset_range)
+          @assets.push(asset)
+          @assets.flatten!
+        end
       end
     end
 

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -205,16 +205,13 @@ module Nexpose
     def remove_ip(ip)
       ip = IPRange.new(ip)
       @assets.each do |asset_range|
-        next if asset_range.is_a?(Nexpose::HostName)
-        if asset_range.include?(ip)
-          asset = split_ip_range(asset_range, ip)
-          @assets.delete(asset_range)
-          @assets.push(asset)
-          @assets.flatten!
-        end
+        next unless asset_range.include?(ip)
+        asset = split_ip_range(asset_range, ip)
+        @assets.delete(asset_range)
+        @assets.push(asset)
+        @assets.flatten!
       end
     end
-
 
     def split_ip_range(ip_range, split_ip)
       split_ip = IPAddr.new(split_ip.from)
@@ -234,7 +231,6 @@ module Nexpose
       return asset
     end
 
-
     def ip_range_split_calc(start_ip, end_ip, split_ip)
       low_split  = IPAddr.new(split_ip.to_i - 1, start_ip.family).to_s
       high_split = IPAddr.new(split_ip.to_i + 1, end_ip.family).to_s
@@ -242,10 +238,8 @@ module Nexpose
       low_range  = Nexpose::IPRange.new(start_ip.to_s, low_split)
       high_range = Nexpose::IPRange.new(high_split, end_ip.to_s)
 
-      return [ low_range, high_range ]
+      return [low_range, high_range]
     end
-
-
 
     # Adds assets to this site by IP address range.
     #

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -725,19 +725,12 @@ module Nexpose
 
     def include?(single_ip)
       return false unless single_ip.respond_to? :from
-      from = IPAddr.new(@from)
-      to = @to.nil? ? from : IPAddr.new(@to)
-      other = IPAddr.new(single_ip)
+      from = IPAddr.new(@from).to_i
+      to = @to.nil? ? from : IPAddr.new(@to).to_i
+      other = IPAddr.new(single_ip.from).to_i
 
-      if other == from || other == to
-        true
-      elsif other < from
-        false
-      elsif to < other
-        false
-      else
-        true
-      end
+      (from..to).include?(other)
+
     end
 
     def hash

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -219,7 +219,9 @@ module Nexpose
       ip = IPRange.new(ip)
       @assets.each do |asset_range|
         return if asset_range.is_a?(Nexpose::HostName)
-        if asset_range.include?(ip)
+        if asset_range == ip
+          @assets.delete(asset_range)
+        elsif asset_range.include?(ip)
           asset = split_ip_range(asset_range, ip)
           @assets.delete(asset_range)
           @assets.push(asset)

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -203,8 +203,49 @@ module Nexpose
     #
     # @param [String] ip IP address of an asset.
     def remove_ip(ip)
-      @assets = assets.reject { |asset| asset == IPRange.new(ip) }
+      ip = IPRange.new(ip)
+      @assets.each do |asset_range|
+        next if asset_range.is_a?(Nexpose::HostName)
+        if asset_range.include?(ip)
+          asset = split_ip_range(asset_range, ip)
+          @assets.delete(asset_range)
+          @assets.push(asset)
+          @assets.flatten!
+        end
+      end
     end
+
+
+    def split_ip_range(ip_range, split_ip)
+      split_ip = IPAddr.new(split_ip.from)
+      start_ip, end_ip = IPAddr.new(ip_range.from), IPAddr.new(ip_range.to)
+      all_ip_range = (start_ip..end_ip)
+
+      case split_ip
+      when all_ip_range.min
+        new_start = IPAddr.new(start_ip.to_i + 1, start_ip.family).to_s
+        asset = Nexpose::IPRange.new(new_start, ip_range.to)
+      when all_ip_range.max
+        new_end = IPAddr.new(end_ip.to_i - 1, end_ip.family).to_s
+        asset = Nexpose::IPRange.new(ip_range.from, new_end)
+      else
+        asset = ip_range_split_calc(start_ip, end_ip, split_ip)
+      end
+      return asset
+    end
+
+
+    def ip_range_split_calc(start_ip, end_ip, split_ip)
+      low_split  = IPAddr.new(split_ip.to_i - 1, start_ip.family).to_s
+      high_split = IPAddr.new(split_ip.to_i + 1, end_ip.family).to_s
+
+      low_range  = Nexpose::IPRange.new(start_ip.to_s, low_split)
+      high_range = Nexpose::IPRange.new(high_split, end_ip.to_s)
+
+      return [ low_range, high_range ]
+    end
+
+
 
     # Adds assets to this site by IP address range.
     #
@@ -728,9 +769,7 @@ module Nexpose
       from = IPAddr.new(@from).to_i
       to = @to.nil? ? from : IPAddr.new(@to).to_i
       other = IPAddr.new(single_ip.from).to_i
-
       (from..to).include?(other)
-
     end
 
     def hash

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -27,6 +27,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0.29.0')
   s.add_development_dependency('webmock', '~> 1.20.4')
   s.add_development_dependency('vcr', '~> 2.9.3')
-  s.add_development_dependency('pry')
-  s.add_development_dependency('pry-byebug')
 end

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0.29.0')
   s.add_development_dependency('webmock', '~> 1.20.4')
   s.add_development_dependency('vcr', '~> 2.9.3')
+  s.add_development_dependency('pry')
+  s.add_development_dependency('pry-byebug')
 end

--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -1,1 +1,2 @@
 RSpec::Matchers.alias_matcher :a_site_matching, :have_attributes
+RSpec::Matchers.alias_matcher :include_asset, :be_include_asset

--- a/spec/nexpose/site/ip_range_spec.rb
+++ b/spec/nexpose/site/ip_range_spec.rb
@@ -74,6 +74,34 @@ describe Nexpose::IPRange do
     end
   end
 
+  describe '#include?' do
+    subject { Nexpose::IPRange.new('192.168.1.0', '192.168.1.255') }
+
+    context 'with a invalid IP string' do
+      it 'returns false' do
+        expect(subject).to_not include('127.0.0.1')
+      end
+    end
+
+    context 'with a valid IP string' do
+      it 'returns true' do
+        expect(subject).to include('192.168.1.1')
+      end
+    end
+
+    context 'with an invalid IPRange' do
+      it 'returns false' do
+        expect(subject).to_not include(Nexpose::IPRange.new('127.0.0.1'))
+      end
+    end
+
+    context 'with a subset in an IPRange' do
+      it 'returns true' do
+        expect(subject).to include(Nexpose::IPRange.new('192.168.1.1'))
+      end
+    end
+  end
+
   describe '#size' do
     context 'with a single IP address' do
       subject { Nexpose::IPRange.new('192.168.1.0') }

--- a/spec/nexpose/site/ip_range_spec.rb
+++ b/spec/nexpose/site/ip_range_spec.rb
@@ -83,12 +83,6 @@ describe Nexpose::IPRange do
       end
     end
 
-    context 'with a valid IP string' do
-      it 'returns true' do
-        expect(subject).to include('192.168.1.1')
-      end
-    end
-
     context 'with an invalid IPRange' do
       it 'returns false' do
         expect(subject).to_not include(Nexpose::IPRange.new('127.0.0.1'))

--- a/spec/nexpose/site_spec.rb
+++ b/spec/nexpose/site_spec.rb
@@ -81,7 +81,7 @@ describe Nexpose::Site do
         expect(subject).to_not include_asset('172.16.0.1')
       end
 
-      it 'deletes a lone IP' do
+      it 'splits a range after deleting an IP' do
         subject.remove_asset('192.168.0.100')
         expect(subject).to_not include_asset('192.168.0.100')
       end

--- a/spec/nexpose/site_spec.rb
+++ b/spec/nexpose/site_spec.rb
@@ -56,4 +56,35 @@ describe Nexpose::Site do
       end
     end
   end
+
+  describe '#remove_asset' do
+    context 'with multiple IP addresses and ranges' do
+      before do
+        subject.add_ip_range('192.168.0.100', '192.168.0.105')
+        subject.add_ip_range('172.16.0.1', '172.16.0.3')
+        subject.add_asset('172.16.0.5')
+        subject.add_asset('example.local')
+      end
+
+      it 'deletes a hostname' do
+        subject.remove_asset('example.local')
+        expect(subject).to_not include_asset('example.local')
+      end
+
+      it 'deletes a lone IP' do
+        subject.remove_asset('172.16.0.5')
+        expect(subject).to_not include_asset('172.16.0.5')
+      end
+
+      it 'deletes an IP embedded in a range' do
+        subject.remove_asset('172.16.0.1')
+        expect(subject).to_not include_asset('172.16.0.1')
+      end
+
+      it 'deletes a lone IP' do
+        subject.remove_asset('192.168.0.100')
+        expect(subject).to_not include_asset('192.168.0.100')
+      end
+    end
+  end
 end


### PR DESCRIPTION
An effort to fix https://github.com/rapid7/nexpose-client/issues/148

This should correctly remove a single ip from a range.