### PR TITLE
pass the connection error response up to the authentication error object

### DIFF
--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -69,8 +69,8 @@ module Nexpose
           @session_id = r.sid
           true
         end
-      rescue APIError
-        raise AuthenticationFailed.new(r)
+      rescue APIError => error
+        raise AuthenticationFailed.new(r,error)
       end
     end
 

--- a/lib/nexpose/error.rb
+++ b/lib/nexpose/error.rb
@@ -15,9 +15,9 @@ module Nexpose
   end
 
   class AuthenticationFailed < APIError
-    def initialize(req)
+    def initialize(req, reason = nil)
       @req = req
-      @reason = "Login Failed"
+      @reason = reason ||= "Login Failed"
     end
   end
 


### PR DESCRIPTION
Make sure the errors that we get during login are correctly sent over to the AuthenticationFailed object.