### PR TITLE
Add DHCP Protocol/Type constants to the DiscoveryConnection class

### DIFF
--- a/lib/nexpose/discovery.rb
+++ b/lib/nexpose/discovery.rb
@@ -35,6 +35,7 @@ module Nexpose
       HTTPS = 'HTTPS'
       LDAP  = 'LDAP'
       LDAPS = 'LDAPS'
+      SERVICE_PROXY = 'SERVICE_PROXY'
     end
 
     module Type
@@ -43,6 +44,7 @@ module Nexpose
       ACTIVESYNC            = 'ACTIVESYNC'
       ACTIVESYNC_POWERSHELL = 'ACTIVESYNC_POWERSHELL'
       ACTIVESYNC_OFFICE365  = 'ACTIVESYNC_OFFICE365'
+      DHCP_SERVICE = 'DHCP_SERVICE'
     end
 
     # A unique identifier for this connection.


### PR DESCRIPTION
# Example
```ruby
nexpose_connection = Nexpose::Connection.new(hostname, nexpose_user, nexpose_password)

discovery_connection = Nexpose::DiscoveryConnection.new(
  connection_name,
  log_directory,
  cifs_user,
  cifs_password
)
engine = nexpose_connection.engines.find { |connection| connection.name.eql?('Local scan engine') }
discovery_connection.engine_id = engine.id
discovery_connection.protocol = Nexpose::DiscoveryConnection::Protocol::SERVICE_PROXY
discovery_connection.type = Nexpose::DiscoveryConnection::Type::DHCP_SERVICE

# Save a new DHCP discovery connection
discovery_connection.save(nexpose_connection)

# Delete a DHCP discovery connection
discovery_connection.delete(nexpose_connection)
```