### PR TITLE
Reorder optional arguments for better use case of SiteCredentials#for_service

### DIFF
--- a/lib/nexpose/site_credentials.rb
+++ b/lib/nexpose/site_credentials.rb
@@ -56,8 +56,8 @@ module Nexpose
     # scope of credential
     attr_accessor :scope
 
-    #Create a credential object using name, id, description, host and port
-    def self.for_service(name, id = -1, desc = nil, host = nil, port = nil, service = Credential::Service::CIFS)
+    # Create a credential object using name, id, description, host and port
+    def self.for_service(name, service = Credential::Service::CIFS, id = -1, desc = nil, host = nil, port = nil)
       cred = new
       cred.name = name
       cred.id = id.to_i


### PR DESCRIPTION
The method signature as it currently stands makes little sense, since the user would easily want to define the service type with a single method call. Currently I have to implement something like this, forcing myself to be careful not to accidentally alter the other arguments `-1, nil, nil, nil`:

    credentials = Nexpose::SiteCredentials.for_service(name, -1, nil, nil, nil, service=service)
    credentials.user_name = username
    credentials.password = password

Whereas our current cucumber code has to call a specific method for each type of service

    ssh = Nexpose::SiteCredentials.for_service('ssh')
    ssh.set_ssh_service('root', 'notpassword')

I remain highly dubious about the sanity and scalability of this design pattern. All I want to accomplish here is to be able to call `credentials = Nexpose::SiteCredentials.for_service(name, service)` and be done with it. This change should be fairly safe since I haven't seen any other usages of the method that involve optional parameters.