### PR TITLE
Set default elevation type for credentials

### DIFF
--- a/lib/nexpose/site_credentials.rb
+++ b/lib/nexpose/site_credentials.rb
@@ -67,7 +67,7 @@ module Nexpose
       cred.port_restriction = port
       cred.service = service
       cred.scope = Credential::Scope::SITE_SPECIFIC
-      cred.permission_elevation_type = ElevationType::NONE
+      cred.permission_elevation_type = Credential::ElevationType::NONE
       cred
     end
 

--- a/lib/nexpose/site_credentials.rb
+++ b/lib/nexpose/site_credentials.rb
@@ -67,6 +67,7 @@ module Nexpose
       cred.port_restriction = port
       cred.service = service
       cred.scope = Credential::Scope::SITE_SPECIFIC
+      cred.permission_elevation_type = ElevationType::NONE
       cred
     end
 


### PR DESCRIPTION
This is a simple change that prevents the issue where if the credentials are set without explicitly setting the elevation type (`cred.permission_elevation_type = nil`), the API responds with the following error:

    /home/csong/.rvm/gems/ruby-2.2.0@vuln-tools/gems/nexpose-1.0.0/lib/nexpose/ajax.rb:166:in `request': NexposeAPI: POST request to /api/2.1/site_configurations/ failed. response body: {"errors":["Permission Elevation User must be specified for this action."]} (Nexpose::APIError)
	from /home/csong/.rvm/gems/ruby-2.2.0@vuln-tools/gems/nexpose-1.0.0/lib/nexpose/ajax.rb:65:in `post'
	from /home/csong/.rvm/gems/ruby-2.2.0@vuln-tools/gems/nexpose-1.0.0/lib/nexpose/site.rb:557:in `save'