### PR TITLE
Update FilteredAsset to support site_id in Nexpose 5.13 and later

### DIFF
--- a/lib/nexpose/filter.rb
+++ b/lib/nexpose/filter.rb
@@ -375,7 +375,11 @@ module Nexpose
     attr_reader :vuln_count
     attr_reader :risk_score
 
+    # The first Site ID returned for this asset.
+    # Not recommended  if Asset Linking feature is enabled.
     attr_reader :site_id
+    # Array of Site IDs for the asset. Use when Asset Linking is enabled.
+    attr_reader :site_ids
     attr_reader :last_scan
 
     def initialize(json)
@@ -387,7 +391,11 @@ module Nexpose
       @malware_count = json['malwareCount'].to_i
       @vuln_count = json['vulnCount'].to_i
       @risk_score = json['riskScore'].to_f
-      @site_id = json['siteID']
+      @site_ids = []
+      json['sitePermissions'].each do |site_perm|
+        @site_ids << site_perm['siteID']
+      end
+      @site_id = @site_ids.first
       @last_scan = Time.at(json['lastScanDate'].to_i / 1000)
     end
   end

--- a/lib/nexpose/filter.rb
+++ b/lib/nexpose/filter.rb
@@ -376,7 +376,7 @@ module Nexpose
     attr_reader :risk_score
 
     # The first Site ID returned for this asset.
-    # Not recommended  if Asset Linking feature is enabled.
+    # Not recommended if Asset Linking feature is enabled.
     attr_reader :site_id
     # Array of Site IDs for the asset. Use when Asset Linking is enabled.
     attr_reader :site_ids
@@ -391,10 +391,7 @@ module Nexpose
       @malware_count = json['malwareCount'].to_i
       @vuln_count = json['vulnCount'].to_i
       @risk_score = json['riskScore'].to_f
-      @site_ids = []
-      json['sitePermissions'].each do |site_perm|
-        @site_ids << site_perm['siteID']
-      end
+      @site_ids = json['sitePermissions'].map { |site| site['siteID'] }
       @site_id = @site_ids.first
       @last_scan = Time.at(json['lastScanDate'].to_i / 1000)
     end


### PR DESCRIPTION
Resolves #178.

- Add site_ids attribute, array of 1 or more site IDs
- Change site_id to get first ID from site_ids

Note that consoles which do not have Asset Linking enabled can use site_id without any issues. However, consoles with Asset Linking enabled should use site_ids instead because site_id may not be the "correct" or expected site_id, depending on the order they are returned.

This will require a version bump to 1.3.0.

Note that all nexpose-client gem versions since 1.0.0 are not backwards-compatible with Nexpose versions prior to 5.13.0.

Testing done:
- [x] Console without Asset Linking enabled
- [x] Console with Asset Linking enabled
- [x] Multi-Tenant console where one silo has Asset Linking enabled and another does not