### PR TITLE
Refactor, enhance and fix bugs in ScanTemplate

### DIFF
--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -318,7 +318,7 @@ module Nexpose
     #
     def checks_by_category
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
-      checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] }
+      checks ? checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] } : []
     end
 
     # Enable checks by category for this template.
@@ -352,7 +352,7 @@ module Nexpose
     #
     def checks_by_type
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
-      checks.elements.to_a('CheckType').map { |c| c.attributes['name'] }
+      checks ? checks.elements.to_a('CheckType').map { |c| c.attributes['name'] } : []
     end
 
     # Enable checks by type for this template.
@@ -404,7 +404,7 @@ module Nexpose
     #
     def vuln_checks
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
-      checks.elements.to_a('Check').map { |c| c.attributes['id'] }
+      checks ? checks.elements.to_a('Check').map { |c| c.attributes['id'] } : []
     end
 
     # Enable individual check for this template.

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -383,7 +383,8 @@ module Nexpose
     def _enable_check(check, elem)
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Disabled/#{elem}[@name='#{check}']")
-      checks.elements['Enabled'].add_element(elem, { 'name' => check })
+      enabled_checks = checks.elements['Enabled'] || checks.add_element('Enabled')
+      enabled_checks.add_element(elem, { 'name' => check })
     end
 
     def _disable_check(check, elem)

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -414,7 +414,8 @@ module Nexpose
     def enable_vuln_check(check_id)
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Disabled/Check[@id='#{check_id}']")
-      checks.elements['Enabled'].add_element('Check', { 'id' => check_id })
+      enabled_checks = checks.elements['Enabled'] || checks.add_element('Enabled')
+      enabled_checks.add_element('Check', { 'id' => check_id })
     end
 
     # Disable individual check for this template.

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -321,6 +321,12 @@ module Nexpose
       checks ? checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] } : []
     end
 
+    # @deprecated Use {#enabled_checks_by_category} instead
+    def checks_by_category
+      warn "[DEPRECATED] Use #{self.class}#enabled_checks_by_category instead of #{self.class}##{__method__}"
+      enabled_checks_by_category
+    end
+
     # Get a list of the check categories enabled for this scan template.
     #
     # @return [Array[String]] List of enabled categories.
@@ -362,6 +368,12 @@ module Nexpose
     def disabled_checks_by_type
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Disabled')
       checks ? checks.elements.to_a('CheckType').map { |c| c.attributes['name'] } : []
+    end
+
+    # @deprecated Use {#enabled_checks_by_type} instead
+    def checks_by_type
+      warn "[DEPRECATED] Use #{self.class}#enabled_checks_by_type instead of #{self.class}##{__method__}"
+      enabled_checks_by_type
     end
 
     # Get a list of the check types enabled for this scan template.
@@ -416,6 +428,12 @@ module Nexpose
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Disabled/#{elem}[@name='#{check}']")
       checks.elements.delete("Enabled/#{elem}[@name='#{check}']")
+    end
+
+    # @deprecated Use {#enabled_vuln_checks} instead
+    def vuln_checks
+      warn "[DEPRECATED] Use #{self.class}#enabled_vuln_checks instead of #{self.class}##{__method__}"
+      enabled_vuln_checks
     end
 
     # Get a list of the individual vuln checks enabled for this scan template.

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -312,11 +312,20 @@ module Nexpose
       checks.attributes['potential'] = enable ? '1' : '0'
     end
 
+    # Get a list of the check categories disabled for this scan template.
+    #
+    # @return [Array[String]] List of enabled categories.
+    #
+    def disabled_checks_by_category
+      checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Disabled')
+      checks ? checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] } : []
+    end
+
     # Get a list of the check categories enabled for this scan template.
     #
     # @return [Array[String]] List of enabled categories.
     #
-    def checks_by_category
+    def enabled_checks_by_category
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
       checks ? checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] } : []
     end
@@ -346,11 +355,20 @@ module Nexpose
       _remove_check(category, 'VulnCategory')
     end
 
+    # Get a list of the check types disabled for this scan template.
+    #
+    # @return [Array[String]] List of enabled check types.
+    #
+    def disabled_checks_by_type
+      checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Disabled')
+      checks ? checks.elements.to_a('CheckType').map { |c| c.attributes['name'] } : []
+    end
+
     # Get a list of the check types enabled for this scan template.
     #
     # @return [Array[String]] List of enabled check types.
     #
-    def checks_by_type
+    def enabled_checks_by_type
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
       checks ? checks.elements.to_a('CheckType').map { |c| c.attributes['name'] } : []
     end
@@ -390,7 +408,8 @@ module Nexpose
     def _disable_check(check, elem)
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Enabled/#{elem}[@name='#{check}']")
-      checks.elements['Disabled'].add_element(elem, { 'name' => check })
+      disabled_checks = checks.elements['Disabled'] || checks.add_element('Disabled')
+      disabled_checks.add_element(elem, { 'name' => check })
     end
 
     def _remove_check(check, elem)
@@ -403,8 +422,17 @@ module Nexpose
     #
     # @return [Array[String]] List of enabled vulnerability checks.
     #
-    def vuln_checks
+    def enabled_vuln_checks
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Enabled')
+      checks ? checks.elements.to_a('Check').map { |c| c.attributes['id'] } : []
+    end
+
+    # Get a list of the individual vuln checks disabled for this scan template.
+    #
+    # @return [Array[String]] List of enabled vulnerability checks.
+    #
+    def disabled_vuln_checks
+      checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Disabled')
       checks ? checks.elements.to_a('Check').map { |c| c.attributes['id'] } : []
     end
 
@@ -426,7 +454,8 @@ module Nexpose
     def disable_vuln_check(check_id)
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Enabled/Check[@id='#{check_id}']")
-      checks.elements['Disabled'].add_element('Check', { 'id' => check_id })
+      disabled_checks = checks.elements['Disabled'] || checks.add_element('Disabled')
+      disabled_checks.add_element('Check', { 'id' => check_id })
     end
 
     # Remove individual check for this template. Removes both enabled and

--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '2.0.3'
+  VERSION = '3.0.0'
 end

--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '3.0.0'
+  VERSION = '2.0.3'
 end

--- a/spec/data/example_template.xml
+++ b/spec/data/example_template.xml
@@ -1,0 +1,110 @@
+<ScanTemplate id="full-audit" configVersion="4">
+ <templateDescription lang="en_us" title="Full audit">Performs a full network audit of all systems using only safe checks, including network-based vulnerabilities, patch/hotfix checking, and application-layer auditing.  Only default ports are scanned, and policy checking is disabled, making this faster than the Exhaustive scan.</templateDescription>
+ <General disableVulnScan="0" disablePolicyScan="0" disableWebSpider="0">
+  <scanThreads>10</scanThreads>
+  <hostThreads>10</hostThreads>
+ </General>
+ <DeviceDiscovery>
+  <networkDiscovery enabled="0"/>
+  <CheckHosts>
+    <icmpHostCheck enabled="1"/>
+    <TCPHostCheck enabled="1">
+      <portList>21,22,23,25,53,80,110,111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080</portList>
+    </TCPHostCheck>
+    <UDPHostCheck enabled="1">
+      <portList>53,67,68,69,123,135,137,138,139,161,162,445,500,514,520,631,1434,1900,4500,5353,49152</portList>
+    </UDPHostCheck>
+  </CheckHosts>
+ </DeviceDiscovery>
+ <ServiceDiscovery>
+  <TCPPortScan mode="default" method="syn">
+   <portList>1-1040</portList>
+  </TCPPortScan>
+  <UDPPortScan mode="default">
+  </UDPPortScan>
+ </ServiceDiscovery>
+ <DiscoveryPerformance>
+  <MaxRetries maxretries="3"/>
+  <MinTimeout mintimeout="500"/>
+  <MaxTimeout maxtimeout="3000"/>
+  <InitTimeout inittimeout="500"/>
+  <MinScanDelay minscandelay="0"/>
+  <MaxScanDelay maxscandelay="0"/>
+  <DefeatRate enabled="1"/>
+  <MinRate minrate="450"/>
+  <MaxRate maxrate="15000"/>
+  <MinParallelism minparallelism="0"/>
+  <MaxParallelism maxparallelism="0"/>
+ </DiscoveryPerformance>
+ <Credentials/>
+ <VulnerabilityChecks unsafe="0" correlate="1">
+  <Disabled>
+   <CheckType name="Policy"/>
+  </Disabled>
+ </VulnerabilityChecks>
+ <FileSearching fileQuota="-1">
+ </FileSearching>
+ <Plugins>
+  <Plugin name="java/AS400Scanner">
+   <param name="minPasswordLength">6</param>
+   <param name="acctLockoutThreshold">3</param>
+   <param name="minSecurityLevel">40</param>
+  </Plugin>
+  <Plugin name="java/CifsScanner">
+   <param name="minPasswordLength">6</param>
+   <param name="acctLockoutThreshold">3</param>
+  </Plugin>
+  <Plugin name="java/HttpScanner">
+   <param name="adaptiveFingerprinting">0</param>
+   <param name="Spider_On">1</param>
+   <param name="Spider_SkipPrinters">1</param>
+   <param name="Spider_IncludeURLQueries">0</param>
+   <param name="Spider_RunXSSTests">1</param>
+   <param name="Spider_RunSQLInjectionTests">1</param>
+   <param name="Spider_MaxDepth">6</param>
+   <param name="Spider_MaxTimePerWebsite">0</param>
+   <param name="Spider_MaxPagesPerWebsite">3000</param>
+   <param name="Spider_SearchForBackupScripts">1</param>
+   <param name="Spider_HonorRobots">0</param>
+   <param name="Spider_CheckCommonPasswords">0</param>
+   <param name="Spider_MaxThreadsPerEndpoint">3</param>
+   <param name="Spider_MaxRetries">2</param>
+   <param name="Spider_ReadTimeout">120000</param>
+   <param name="Spider_SkipDaemons">Virata-EmWeb, Allegro-Software-RomPager, JetDirect, HP JetDirect, HP Web Jetadmin, HP-ChaiSOE, HP-ChaiServer, CUPS, DigitalV6-HTTPD, Rapid Logic, Agranat-EmWeb, cisco-IOS, RAC_ONE_HTTP, RMC Webserver, EWS-NIC3, EMWHTTPD, IOS, ESWeb</param>
+   <param name="Spider_UserAgent">Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)</param>
+   <param name="spamRecipient">user@example.com</param>
+  </Plugin>
+  <Plugin name="java/NetworkScanners">
+   <param name="trustedMacAddressFile"></param>
+   <param name="defaultServicePropertiesFile">default-services.properties</param>
+   <param name="doWhoisLookups">false</param>
+   <param name="ipFingerprintLowThreshold">0.16</param>
+   <param name="ipFingerprintEnabled">1</param>
+   <param name="OSGuessRetryCount">0</param>
+  </Plugin>
+  <Plugin name="java/PostgresScanner">
+   <param name="Default_Database">template1</param>
+  </Plugin>
+  <Plugin name="java/SmtpScanner">
+   <param name="spamRecipient">user@example.com</param>
+   <param name="timeAccuracyThreshold">7200000</param>
+   <param name="readTimeout">30000</param>
+  </Plugin>
+  <Plugin name="java/TelnetScanner">
+   <param name="terminalCharset">US-ASCII</param>
+  </Plugin>
+  <Plugin name="java/UnixScanner">
+   <param name="umask">077</param>
+  </Plugin>
+  <Plugin name="java/SunPatchScanner">
+  </Plugin>
+  <Plugin name="java/WebSpiderScanner">
+   <param name="Spider_SingleScanPersistent">1</param>
+   <param name="Spider_MaxRefDistance">6</param>
+   <param name="Spider_SensDataNameRegex">(p|pass)(word|phrase|wd|code)</param>
+  </Plugin>
+  <Plugin name="java/OracleScanner">
+   <param name="Default_Databases">ORCL,IASDB,OEMREP,XE,ixos,CTM4_0,CTM4_1,CTM4_6,CTM4_7,ARIS,MSAM,VPX,OPENVIEW,OVO,SA0,SA1,SA2,SA3,SA4,SA5,SA6,SA7,SA8,SA9,SAA,SAB,SAC,SAD,SAE,SAF,SAG,SAH,SAI,SAJ,SAK,SAL,SAM,SAN,SAO,SAP,SAQ,SAR,SAS,SAT,SAU,SAV,SAW,SAX,SAY,SAZ</param>
+  </Plugin>
+ </Plugins>
+</ScanTemplate>

--- a/spec/data/example_template.xml
+++ b/spec/data/example_template.xml
@@ -38,9 +38,6 @@
  </DiscoveryPerformance>
  <Credentials/>
  <VulnerabilityChecks unsafe="0" correlate="1">
-  <Disabled>
-   <CheckType name="Policy"/>
-  </Disabled>
  </VulnerabilityChecks>
  <FileSearching fileQuota="-1">
  </FileSearching>

--- a/spec/nexpose/scan_template_spec.rb
+++ b/spec/nexpose/scan_template_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Nexpose::ScanTemplate do
+  let(:template) { Nexpose::ScanTemplate.new(SecureRandom.hex(16)) }
+
+  describe '#vuln_checks' do
+    context 'by default' do
+      it 'returns no enabled vuln categories' do
+        expect(template.checks_by_category).to be_empty
+      end
+      it 'returns no enabled vuln types' do
+        expect(template.checks_by_type).to be_empty
+      end
+      it 'returns no enabled vuln checks' do
+        expect(template.vuln_checks).to be_empty
+      end
+    end
+  end
+end

--- a/spec/nexpose/scan_template_spec.rb
+++ b/spec/nexpose/scan_template_spec.rb
@@ -1,18 +1,78 @@
 require 'spec_helper'
+require 'securerandom'
 
 describe Nexpose::ScanTemplate do
-  let(:template) { Nexpose::ScanTemplate.new(SecureRandom.hex(16)) }
+  let(:random_things) { 0.upto(1+rand(10)).to_a.map { |t| SecureRandom.hex(8) } }
+  subject { described_class.new(IO.read(File.join(%w(spec data example_template.xml)))) }
 
-  describe '#vuln_checks' do
+  context 'vulnerability checks' do
     context 'by default' do
-      it 'returns no enabled vuln categories' do
-        expect(template.checks_by_category).to be_empty
+      it 'returns no enabled vulnerability checks' do
+        expect(subject.vuln_checks).to be_empty
       end
-      it 'returns no enabled vuln types' do
-        expect(template.checks_by_type).to be_empty
+    end
+    context 'when checks are enabled' do
+      it 'returns enabled vulnerability checks' do
+        random_things.each do |thing|
+          subject.enable_vuln_check(thing)
+        end
+        expect(subject.vuln_checks).to eq(random_things)
       end
-      it 'returns no enabled vuln checks' do
-        expect(template.vuln_checks).to be_empty
+    end
+    context 'when checks are disabled' do
+      skip 'returns disabled vulnerability checks' do
+        random_things.each do |thing|
+          subject.disable_vuln_check(thing)
+        end
+        expect(subject.vuln_checks).to eq(random_things)
+      end
+    end
+  end
+
+  context 'vulnerability categories' do
+    context 'by default' do
+      it 'returns no enabled vulnerability categories' do
+        expect(subject.checks_by_category).to be_empty
+      end
+    end
+    context 'when categories are enabled' do
+      it 'returns enabled vulnerability categories' do
+        random_things.each do |thing|
+          subject.enable_checks_by_category(thing)
+        end
+        expect(subject.checks_by_category).to eq(random_things)
+      end
+    end
+    context 'when categories are disabled' do
+      skip 'returns disabled vulnerability categories' do
+        random_things.each do |thing|
+          subject.disable_checks_by_category(thing)
+        end
+        expect(subject.checks_by_category).to eq(random_things)
+      end
+    end
+  end
+
+  context 'vulnerability types' do
+    context 'by default' do
+      it 'returns no enabled vulnerability types' do
+        expect(subject.checks_by_type).to be_empty
+      end
+    end
+    context 'when types are enabled' do
+      it 'returns enabled vulnerability types' do
+        random_things.each do |thing|
+          subject.enable_checks_by_type(thing)
+        end
+        expect(subject.checks_by_type).to eq(random_things)
+      end
+    end
+    context 'when types are disabled' do
+      skip 'returns disabled vulnerability types' do
+        random_things.each do |thing|
+          subject.disable_checks_by_type(thing)
+        end
+        expect(subject.checks_by_type).to eq(random_things)
       end
     end
   end

--- a/spec/nexpose/scan_template_spec.rb
+++ b/spec/nexpose/scan_template_spec.rb
@@ -8,7 +8,7 @@ describe Nexpose::ScanTemplate do
   context 'vulnerability checks' do
     context 'by default' do
       it 'returns no enabled vulnerability checks' do
-        expect(subject.vuln_checks).to be_empty
+        expect(subject.enabled_vuln_checks).to be_empty
       end
     end
     context 'when checks are enabled' do
@@ -16,15 +16,15 @@ describe Nexpose::ScanTemplate do
         random_things.each do |thing|
           subject.enable_vuln_check(thing)
         end
-        expect(subject.vuln_checks).to eq(random_things)
+        expect(subject.enabled_vuln_checks).to eq(random_things)
       end
     end
     context 'when checks are disabled' do
-      skip 'returns disabled vulnerability checks' do
+      it 'returns disabled vulnerability checks' do
         random_things.each do |thing|
           subject.disable_vuln_check(thing)
         end
-        expect(subject.vuln_checks).to eq(random_things)
+        expect(subject.disabled_vuln_checks).to eq(random_things)
       end
     end
   end
@@ -32,7 +32,7 @@ describe Nexpose::ScanTemplate do
   context 'vulnerability categories' do
     context 'by default' do
       it 'returns no enabled vulnerability categories' do
-        expect(subject.checks_by_category).to be_empty
+        expect(subject.enabled_checks_by_category).to be_empty
       end
     end
     context 'when categories are enabled' do
@@ -40,15 +40,15 @@ describe Nexpose::ScanTemplate do
         random_things.each do |thing|
           subject.enable_checks_by_category(thing)
         end
-        expect(subject.checks_by_category).to eq(random_things)
+        expect(subject.enabled_checks_by_category).to eq(random_things)
       end
     end
     context 'when categories are disabled' do
-      skip 'returns disabled vulnerability categories' do
+      it 'returns disabled vulnerability categories' do
         random_things.each do |thing|
           subject.disable_checks_by_category(thing)
         end
-        expect(subject.checks_by_category).to eq(random_things)
+        expect(subject.disabled_checks_by_category).to eq(random_things)
       end
     end
   end
@@ -56,7 +56,7 @@ describe Nexpose::ScanTemplate do
   context 'vulnerability types' do
     context 'by default' do
       it 'returns no enabled vulnerability types' do
-        expect(subject.checks_by_type).to be_empty
+        expect(subject.enabled_checks_by_type).to be_empty
       end
     end
     context 'when types are enabled' do
@@ -64,15 +64,15 @@ describe Nexpose::ScanTemplate do
         random_things.each do |thing|
           subject.enable_checks_by_type(thing)
         end
-        expect(subject.checks_by_type).to eq(random_things)
+        expect(subject.enabled_checks_by_type).to eq(random_things)
       end
     end
     context 'when types are disabled' do
-      skip 'returns disabled vulnerability types' do
+      it 'returns disabled vulnerability types' do
         random_things.each do |thing|
           subject.disable_checks_by_type(thing)
         end
-        expect(subject.checks_by_type).to eq(random_things)
+        expect(subject.disabled_checks_by_type).to eq(random_things)
       end
     end
   end

--- a/spec/nexpose/scan_template_spec.rb
+++ b/spec/nexpose/scan_template_spec.rb
@@ -9,6 +9,7 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability checks' do
         expect(subject.enabled_vuln_checks).to be_empty
+        expect(subject.vuln_checks).to be_empty
       end
     end
     context 'when checks are enabled' do
@@ -17,6 +18,7 @@ describe Nexpose::ScanTemplate do
           subject.enable_vuln_check(thing)
         end
         expect(subject.enabled_vuln_checks).to eq(random_things)
+        expect(subject.vuln_checks).to eq(random_things)
       end
     end
     context 'when checks are disabled' do
@@ -33,6 +35,7 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability categories' do
         expect(subject.enabled_checks_by_category).to be_empty
+        expect(subject.checks_by_category).to be_empty
       end
     end
     context 'when categories are enabled' do
@@ -41,6 +44,7 @@ describe Nexpose::ScanTemplate do
           subject.enable_checks_by_category(thing)
         end
         expect(subject.enabled_checks_by_category).to eq(random_things)
+        expect(subject.checks_by_category).to eq(random_things)
       end
     end
     context 'when categories are disabled' do
@@ -57,6 +61,7 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability types' do
         expect(subject.enabled_checks_by_type).to be_empty
+        expect(subject.checks_by_type).to be_empty
       end
     end
     context 'when types are enabled' do
@@ -65,6 +70,7 @@ describe Nexpose::ScanTemplate do
           subject.enable_checks_by_type(thing)
         end
         expect(subject.enabled_checks_by_type).to eq(random_things)
+        expect(subject.checks_by_type).to eq(random_things)
       end
     end
     context 'when types are disabled' do


### PR DESCRIPTION
This started off as a simple fix for working with scan templates that didn't have disabled checks, types or categories and turned into more than that.  I've:

* Made all of the check/category/type enabled listing methods consistently not fail if the template didn't have any explicitly enabled. IOW, fixed this:
```
irb(main):021:0>  t2 = Nexpose::ScanTemplate.new('test')
=> #<Nexpose::ScanTemplate:0x007fb0be248828 @xml=<UNDEFINED> ... </>>
irb(main):022:0> t2.vuln_checks
NoMethodError: undefined method `elements' for nil:NilClass
	from /home/jhart/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nexpose-2.0.2/lib/nexpose/scan_template.rb:407:in `vuln_checks'
	from (irb):22
	from /home/jhart/.rbenv/versions/2.2.1/bin/irb:11:in `<main>'
irb(main):023:0> t2.checks_by_type
NoMethodError: undefined method `elements' for nil:NilClass
	from /home/jhart/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nexpose-2.0.2/lib/nexpose/scan_template.rb:355:in `checks_by_type'
	from (irb):23
	from /home/jhart/.rbenv/versions/2.2.1/bin/irb:11:in `<main>'
irb(main):024:0> t2.checks_by_category
NoMethodError: undefined method `elements' for nil:NilClass
	from /home/jhart/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nexpose-2.0.2/lib/nexpose/scan_template.rb:321:in `checks_by_category'
	from (irb):24
	from /home/jhart/.rbenv/versions/2.2.1/bin/irb:11:in `<main>'
```
* Added similar functionality for disabled 
* Renamed the methods to be more consistent and obvious, adding warnings for the old methods which should be dumped when 3.x happens.
* Unit tested everything
