### PR TITLE
Use a block with file.new to auto-close file ref

### DIFF
--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -407,7 +407,7 @@ module Nexpose
       data = Rex::MIME::Message.new
       data.add_part(site_id.to_s, nil, nil, 'form-data; name="siteid"')
       data.add_part(session_id, nil, nil, 'form-data; name="nexposeCCSessionID"')
-      ::File.new(zip_file, 'rb') do |scan|
+      ::File.open(zip_file, 'rb') do |scan|
         data.add_part(scan.read, 'application/zip', 'binary',
                       "form-data; name=\"scan\"; filename=\"#{zip_file}\"")
       end

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -407,9 +407,10 @@ module Nexpose
       data = Rex::MIME::Message.new
       data.add_part(site_id.to_s, nil, nil, 'form-data; name="siteid"')
       data.add_part(session_id, nil, nil, 'form-data; name="nexposeCCSessionID"')
-      scan = ::File.new(zip_file, 'rb')
-      data.add_part(scan.read, 'application/zip', 'binary',
-                    "form-data; name=\"scan\"; filename=\"#{zip_file}\"")
+      ::File.new(zip_file, 'rb') do |scan|
+        data.add_part(scan.read, 'application/zip', 'binary',
+                      "form-data; name=\"scan\"; filename=\"#{zip_file}\"")
+      end
 
       post = Net::HTTP::Post.new('/data/scan/import')
       post.body = data.to_s


### PR DESCRIPTION
Fixes #190 

I haven't tested this yet, but the behavior should be exactly the same except that the file will auto-close when the block ends. The export scan method also does this, although using the one-liner bracket syntax.