### PR TITLE
Update documentation for list_device_vulns

### DIFF
--- a/lib/nexpose/device.rb
+++ b/lib/nexpose/device.rb
@@ -78,7 +78,7 @@ module Nexpose
     # List the vulnerability findings for a given device ID.
     #
     # @param [Fixnum] dev_id Unique identifier of a device (asset).
-    # @return [Array[Vulnerability]] List of vulnerability findings.
+    # @return [Array[VulnFinding]] List of vulnerability findings.
     #
     def list_device_vulns(dev_id)
       parameters = { 'devid' => dev_id,


### PR DESCRIPTION
Corrected documentation for the list_device_vulns method.

It should return Array(VulnFinding), not Array(Vulnerability).