### PR TITLE
Adhoc scan subset of assets within a site, with a different scan template and scan engine

### DIFF
--- a/lib/nexpose/ajax.rb
+++ b/lib/nexpose/ajax.rb
@@ -187,8 +187,10 @@ module Nexpose
     # is 2.1 or greater otherwise use the request body
     def get_error_message(request, response)
       version = get_request_api_version(request)
-
-      (version >= 2.1 && response.body) ? "response body: #{response.body}" : "request body: #{request.body}"
+      data_request = request.path.include? '/data/'
+      data_request ? response_is_text = (response.content_type.include? 'text/plain') : nil
+      return_response = (version >= 2.1 || (data_request && response_is_text))
+      (return_response && response.body) ? "response body: #{response.body}" : "request body: #{request.body}"
     end
 
     # Execute a block of code while presenving the preferences for any

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -204,6 +204,22 @@ module Nexpose
       Scan.parse(response.res) if response.success
     end
 
+    # Initiate an ad-hoc scan with template and engine.
+    #
+    # @param [Fixnum] site_id Site ID to scan.
+    # @param [Array[String]] assets Hostnames and/or IP addresses to scan.
+    # @param [String] scan_template The scan template ID.
+    # @param [Fixnum] scan_engine The scan engine ID.
+    # @return [Fixnum] Scan ID.
+    def scan_assets_with_template_engine(site_id, assets, scan_template, scan_engine)
+      uri = "/data/site/#{site_id}/scan"
+      params = { 'addressList' => assets.join(','),
+                 'template' => scan_template,
+                 'scanEngine' => scan_engine }
+      scan_id = AJAX.form_post(self, uri, params)
+      scan_id.to_i
+    end
+
     # Utility method for appending a HostName or IPRange object into an
     # XML object, in preparation for ad hoc scanning.
     #

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -204,14 +204,17 @@ module Nexpose
       Scan.parse(response.res) if response.success
     end
 
-    # Initiate an ad-hoc scan with template and engine.
+    # Initiate an ad-hoc scan on a subset of site assets with
+    # a specific scan template and scan engine, which may differ
+    # from the site's defined scan template and scan engine.
     #
     # @param [Fixnum] site_id Site ID to scan.
     # @param [Array[String]] assets Hostnames and/or IP addresses to scan.
     # @param [String] scan_template The scan template ID.
     # @param [Fixnum] scan_engine The scan engine ID.
     # @return [Fixnum] Scan ID.
-    def scan_assets_with_template_engine(site_id, assets, scan_template, scan_engine)
+    #
+    def scan_assets_with_template_and_engine(site_id, assets, scan_template, scan_engine)
       uri = "/data/site/#{site_id}/scan"
       assets.size > 1 ? addresses = assets.join(',') : addresses = assets.first
       params = { 'addressList' => addresses,

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -213,7 +213,8 @@ module Nexpose
     # @return [Fixnum] Scan ID.
     def scan_assets_with_template_engine(site_id, assets, scan_template, scan_engine)
       uri = "/data/site/#{site_id}/scan"
-      params = { 'addressList' => assets.join(','),
+      assets.size > 1 ? addresses = assets.join(',') : addresses = assets.first
+      params = { 'addressList' => addresses,
                  'template' => scan_template,
                  'scanEngine' => scan_engine }
       scan_id = AJAX.form_post(self, uri, params)


### PR DESCRIPTION
I still need feedback on the method name. I added an `and` to it to be more English-y, but it's super long and I'm not a huge fan of it right now.

Changes include:
* New scan method that imitates the "Scan Now" dialog in the Nexpose UI
* Capture error responses from `/data/` endpoints when they are plain text

Additional testing needed:
- [ ] Ensure error handling doesn't negatively impact other methods' errors

Blurb:
This behaves like the "Scan Now" dialog in the UI where you can select a subset of a site's defined assets, a scan template, and a scan engine to scan them with. These settings are not persisted to a site configuration and allows multiple simultaneous scans on a single site.

Example usage:
```ruby
nsc = Nexpose::Connection.new(...)
# Arbitrary site id for this example.
site_id = 1
# Default scan template.
template = 'full-audit-without-web-spider'
# Local scan engine is typically id 3 on newer installs, but can be 2 on older installs.
# Use Nexpose::Connection#list_engines and filter for the engine you want.
engine_id = 3
# Array of 1 or more strings, although passing in Nexpose::IPRange 
# and Nexpose::HostName objects also works correctly.
assets_to_scan = ['example.fqdn', '192.168.1.1', '10.1.5.0 - 10.1.5.60']

scan_id = nsc.scan_assets_with_template_and_engine(site_id, assets_to_scan, template, engine_id)

puts scan_id
```

Resolves #188 