### PR TITLE
Add methods to retrieve paused scans

### DIFF
--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -361,9 +361,9 @@ module Nexpose
     #
     # @param [Fixnum] site_id Site ID to retrieve paused scans for.
     # @param [Fixnum] limit The maximum number of records to return from this call.
-    # @return [ActiveScan] The paused scan details.
+    # @return [Array[ActiveScan]] List of paused scans.
     #
-    def paused_scans(site_id = nil, limit = nil)
+    def paused_scans(site_id, limit = nil)
       uri = "/data/scan/site/#{site_id}?status=active"
       rows = AJAX.row_pref_of(limit)
       params = { 'sort' => 'endTime', 'dir' => 'DESC', 'startIndex' => 0 }
@@ -375,11 +375,12 @@ module Nexpose
 
     # Get paused scans for all sites.
     #
-    # @return [ActiveScan] The paused scan details.
+    # @return [Array[ActiveScan]] List of paused scans.
     #
     def paused_scans
       uri = '/data/site/scans/dyntable.xml?printDocType=0&tableID=siteScansTable&activeOnly=true'
       data = DataTable._get_dyn_table(self, uri).select { |scan| (scan['Status'].include? 'Paused')}
+      data.map(&ActiveScan.method(:parse_dyntable))
     end
 
     # Export the data associated with a single scan, and optionally store it in
@@ -788,10 +789,6 @@ module Nexpose
         :stopped
       when 'A'
         :aborted
-      when 'P'
-        :paused
-      when 'I'
-        :integrating
       else
         :unknown
       end

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -370,12 +370,12 @@ module Nexpose
         rows = AJAX.row_pref_of(limit)
         params = { 'sort' => 'endTime', 'dir' => 'DESC', 'startIndex' => 0 }
         AJAX.preserving_preference(self, 'site-active-scans') do
-          data = DataTable._get_json_table(self, uri, params, rows, limit).select { |scan| scan['paused']}
+          data = DataTable._get_json_table(self, uri, params, rows, limit).select { |scan| scan['paused'] }
           data.map(&ActiveScan.method(:parse_json))
         end
       else
         uri = '/data/site/scans/dyntable.xml?printDocType=0&tableID=siteScansTable&activeOnly=true'
-        data = DataTable._get_dyn_table(self, uri).select { |scan| (scan['Status'].include? 'Paused')}
+        data = DataTable._get_dyn_table(self, uri).select { |scan| (scan['Status'].include? 'Paused') }
         data.map(&ActiveScan.method(:parse_dyntable))
       end
     end

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -357,6 +357,31 @@ module Nexpose
       end
     end
 
+    # Get paused scans for a site.
+    #
+    # @param [Fixnum] site_id Site ID to retrieve paused scans for.
+    # @param [Fixnum] limit The maximum number of records to return from this call.
+    # @return [ActiveScan] The paused scan details.
+    #
+    def paused_scans(site_id = nil, limit = nil)
+      uri = "/data/scan/site/#{site_id}?status=active"
+      rows = AJAX.row_pref_of(limit)
+      params = { 'sort' => 'endTime', 'dir' => 'DESC', 'startIndex' => 0 }
+      AJAX.preserving_preference(self, 'site-active-scans') do
+        data = DataTable._get_json_table(self, uri, params, rows, limit).select { |scan| scan['paused']}
+        data.map(&ActiveScan.method(:parse_json))
+      end
+    end
+
+    # Get paused scans for all sites.
+    #
+    # @return [ActiveScan] The paused scan details.
+    #
+    def paused_scans
+      uri = '/data/site/scans/dyntable.xml?printDocType=0&tableID=siteScansTable&activeOnly=true'
+      data = DataTable._get_dyn_table(self, uri).select { |scan| (scan['Status'].include? 'Paused')}
+    end
+
     # Export the data associated with a single scan, and optionally store it in
     # a zip-compressed file under the provided name.
     #
@@ -763,6 +788,42 @@ module Nexpose
         :stopped
       when 'A'
         :aborted
+      when 'P'
+        :paused
+      when 'I'
+        :integrating
+      else
+        :unknown
+      end
+    end
+  end
+
+  class ActiveScan < CompletedScan
+    def self.parse_dyntable(json)
+      new do
+        @id = json['Scan ID']
+        @site_id = json['Site ID']
+        @status = CompletedScan._parse_status(json['Status Code'])
+        @start_time = Time.at(json['Started'].to_i / 1000)
+        @end_time = Time.at(json['Progress'].to_i / 1000)
+        @duration = json['Elapsed'].to_i
+        @vulns = json['Vulnerabilities Discovered'].to_i
+        @assets = json['Devices Discovered'].to_i
+        @risk_score = json['riskScore']
+        @type = json['Scan Type'] == 'Manual' ? :manual : :scheduled
+        @engine_name = json['Scan Engine']
+      end
+    end
+
+    # Internal method to parsing status codes.
+    def self._parse_status(code)
+      case code
+      when 'U'
+        :running
+      when 'P'
+        :paused
+      when 'I'
+        :integrating
       else
         :unknown
       end


### PR DESCRIPTION
Two separate methods for site scans and all scans using two different data table endpoints. This may or may not allow for some more efficiency when checking specific sites.

Added new class ActiveScan based on CompletedScan to handle parsing the data differently.

Testing required:
- [ ] Get paused scans for specific sites
- [ ] Get all paused scans
- [ ] Get paused scans when there are also running scans
- [ ] Get paused scans when there are also integrating scans
- [ ] Scheduled scans paused by schedule
- [ ] Scheduled scans paused by user
- [ ] Manual scans paused by user

A pre-built gem can be downloaded at http://gavinws.com/nexpose-2.3.0.pre.gem otherwise set your gemfile to use my fork and branch.

Resolves #193