### PR TITLE
Add asset_scan_history method

### DIFF
--- a/lib/nexpose/device.rb
+++ b/lib/nexpose/device.rb
@@ -130,6 +130,21 @@ module Nexpose
     end
 
     alias_method :delete_asset, :delete_device
+
+    # Retrieve the scan history for an asset.
+    # Note: This is not optimized for querying many assets.
+    #
+    # @param [Fixnum] asset_id Unique identifer of an asset.
+    # @return [Array[AssetScan]] A list of scans for the asset.
+    #
+    def asset_scan_history(asset_id)
+      uri = "/data/assets/#{asset_id}/scans"
+      AJAX.preserving_preference(self, 'asset-scan-history') do
+        data = DataTable._get_json_table(self, uri, {}, 500, nil, true)
+        data.each { |a| a['assetID'] = asset_id.to_s }
+        data.map(&AssetScan.method(:parse_json))
+      end
+    end
   end
 
   # Object that represents a single device in a Nexpose security console.
@@ -207,5 +222,51 @@ module Nexpose
   # Summary object of an incomplete asset for a scan.
   #
   class IncompleteAsset < CompletedAsset
+  end
+
+
+  # Summary object of a scan for a particular asset.
+  #
+  class AssetScan
+    # Unique identifier of an asset.
+    attr_reader :asset_id
+    # IP address of the asset.
+    attr_reader :ip
+    # Host name of the asset, if discovered.
+    attr_reader :host_name
+    # Site name where the scan originated.
+    attr_reader :site_name
+    # Unique identifier for the site where the scan originated.
+    attr_reader :site_id
+    # Unique identifier for the scan.
+    attr_reader :scan_id
+    # Time when the asset finished scanning.
+    attr_reader :end_time
+    # Number of vulnerabilities discovered on the asset.
+    attr_reader :vulns
+    # Operating system fingerprint of the asset.
+    attr_reader :os
+    # Name of the scan engine used for the scan.
+    attr_reader :engine_name
+
+    # Internal constructor to be called by #parse_json.
+    def initialize(&block)
+      instance_eval(&block) if block_given?
+    end
+
+    def self.parse_json(json)
+      new do
+        @asset_id = json['assetID'].to_i
+        @scan_id = json['scanID'].to_i
+        @site_id = json['siteID'].to_i
+        @ip = json['ipAddress']
+        @host_name = json['hostname']
+        @os = json['operatingSystem']
+        @vulns = json['vulnCount']
+        @end_time = Time.at(json['completed'].to_i / 1000)
+        @site_name = json['siteName']
+        @engine_name = json['scanEngineName']
+      end
+    end
   end
 end


### PR DESCRIPTION
This is convenient for a small number of assets, but performance does not scale well for many assets. Something like ~25 assets took 30+ seconds to return using the below example. I was inspired by this community discussion: https://community.rapid7.com/thread/7780

Example usage, retrieving the last scan for assets with 'centos' in their hostname:
```ruby
assets = nsc.filter(Nexpose::Search::Field::ASSET, Nexpose::Search::Operator::CONTAINS, 'centos')

last_scans = []

assets.each { |asset| last_scans << nsc.asset_scan_history(asset.id).first }

last_scans.each { |scan| puts "Asset: #{scan.asset_id}, IP: #{scan.ip}, Name: #{scan.host_name}, Scan: #{scan.scan_id}, Site: #{scan.site_id}, Engine: #{scan.engine_name}" }

```

Example AssetScan object:
```ruby
#<AssetScan:0x007f80c338a8b0
 @asset_id=1777,
 @end_time=2015-11-13 15:34:50 -0800,
 @engine_name="Local scan engine",
 @host_name="centos-linux",
 @ip="192.168.1.2",
 @os="Linux 2.6.32-71.el6.x86_64",
 @scan_id=238,
 @site_id=270,
 @site_name="My Linux Site",
 @vulns=12>
```