### PR TITLE
Extract Rex::MIME dependency

### DIFF
--- a/lib/nexpose.rb
+++ b/lib/nexpose.rb
@@ -53,10 +53,10 @@ require 'rexml/document'
 require 'net/https'
 require 'net/http'
 require 'uri'
-require 'rex/mime'
 require 'ipaddr'
 require 'json'
 require 'cgi'
+require 'nexpose/rexlite/mime'
 require 'nexpose/api'
 require 'nexpose/json_serializer'
 require 'nexpose/error'
@@ -114,13 +114,5 @@ module Nexpose
   def self.print_xml(object)
     puts 'request: ' + object.request_xml.to_s
     puts 'response: ' + object.response_xml.to_s
-  end
-end
-
-# Monkey patch from ActiveSupport which rex 2.0.3 incorrectly replies upon.
-# This enables the multipart MIME handling in Connection#import_scan
-class String
-  def blank?
-    self !~ /\S/
   end
 end

--- a/lib/nexpose/report.rb
+++ b/lib/nexpose/report.rb
@@ -249,7 +249,7 @@ module Nexpose
           content_type_response = content_type_response[0, last_semi_colon_index]
 
           data = 'Content-Type: ' + content_type_response + "\r\n\r\n" + response.raw_response_data
-          doc = Rex::MIME::Message.new(data)
+          doc = Rexlite::MIME::Message.new(data)
           doc.parts.each do |part|
             if /.*base64.*/ =~ part.header.to_s
               if @format =~ /(?:ht|x)ml/

--- a/lib/nexpose/rexlite/README.md
+++ b/lib/nexpose/rexlite/README.md
@@ -1,0 +1,5 @@
+# Rexlite
+
+This is an extraction of the [Rex library](https://github.com/rapid7/rex) to reduce dependencies for the nexpose-client gem.
+
+Currently only the Rex::MIME module has been pulled over since that is the only dependency that nexpose-client has on Rex.

--- a/lib/nexpose/rexlite/mime.rb
+++ b/lib/nexpose/rexlite/mime.rb
@@ -1,10 +1,10 @@
 # -*- coding: binary -*-
 module Rexlite
-module MIME
+  module MIME
 
-require 'nexpose/rexlite/mime/header'
-require 'nexpose/rexlite/mime/part'
-require 'nexpose/rexlite/mime/message'
+    require 'nexpose/rexlite/mime/header'
+    require 'nexpose/rexlite/mime/part'
+    require 'nexpose/rexlite/mime/message'
 
-end
+  end
 end

--- a/lib/nexpose/rexlite/mime.rb
+++ b/lib/nexpose/rexlite/mime.rb
@@ -1,0 +1,10 @@
+# -*- coding: binary -*-
+module Rexlite
+module MIME
+
+require 'nexpose/rexlite/mime/header'
+require 'nexpose/rexlite/mime/part'
+require 'nexpose/rexlite/mime/message'
+
+end
+end

--- a/lib/nexpose/rexlite/mime/encoding.rb
+++ b/lib/nexpose/rexlite/mime/encoding.rb
@@ -1,17 +1,17 @@
 # -*- coding: binary -*-
 module Rexlite
-module MIME
-# Set of helpers methods to deal with SMTP encoding related topics.
-module Encoding
+  module MIME
+    # Set of helpers methods to deal with SMTP encoding related topics.
+    module Encoding
 
-  # Enforces CRLF on the input data
-  #
-  # @param data [String] The data to CRLF enforce.
-  # @return [String] CRLF enforced data.
-  def force_crlf(data)
-    data.gsub("\r", '').gsub("\n", "\r\n")
+      # Enforces CRLF on the input data
+      #
+      # @param data [String] The data to CRLF enforce.
+      # @return [String] CRLF enforced data.
+      def force_crlf(data)
+        data.gsub("\r", '').gsub("\n", "\r\n")
+      end
+
+    end
   end
-
-end
-end
 end

--- a/lib/nexpose/rexlite/mime/encoding.rb
+++ b/lib/nexpose/rexlite/mime/encoding.rb
@@ -1,0 +1,17 @@
+# -*- coding: binary -*-
+module Rexlite
+module MIME
+# Set of helpers methods to deal with SMTP encoding related topics.
+module Encoding
+
+  # Enforces CRLF on the input data
+  #
+  # @param data [String] The data to CRLF enforce.
+  # @return [String] CRLF enforced data.
+  def force_crlf(data)
+    data.gsub("\r", '').gsub("\n", "\r\n")
+  end
+
+end
+end
+end

--- a/lib/nexpose/rexlite/mime/header.rb
+++ b/lib/nexpose/rexlite/mime/header.rb
@@ -1,77 +1,76 @@
 # -*- coding: binary -*-
 module Rexlite
-module MIME
-class Header
+  module MIME
+    class Header
 
-  attr_accessor :headers
+      attr_accessor :headers
 
-  def initialize(data='')
-    self.headers = []
-    parse(data)
-  end
-
-  def parse(data)
-    prev = nil
-    data.gsub("\r", '').split("\n").each do |line|
-
-      # Handle header folding
-      if (line =~ /^\s+/)
-        # Ignore if there is no previous header
-        next if not prev
-        next if not self.headers[prev]
-        self.headers[prev][1] << line.strip
-        next
+      def initialize(data='')
+        self.headers = []
+        parse(data)
       end
 
-      var, val = line.split(':', 2)
-      next if val.nil?
+      def parse(data)
+        prev = nil
+        data.gsub("\r", '').split("\n").each do |line|
 
-      self.headers << [ var.to_s.strip, val.to_s.strip ]
-      prev = self.headers.length - 1
-    end
-  end
+          # Handle header folding
+          if (line =~ /^\s+/)
+            # Ignore if there is no previous header
+            next if not prev
+            next if not self.headers[prev]
+            self.headers[prev][1] << line.strip
+            next
+          end
 
-  def to_s
-    self.headers.map{ |pair| "#{pair[0]}: #{pair[1]}\r\n" }.join
-  end
+          var, val = line.split(':', 2)
+          next if val.nil?
 
-  def find(idx)
-    if (idx.class == ::Fixnum)
-      return self.headers[idx]
-    else
-      self.headers.each do |pair|
-        if (pair[0] == idx.to_s)
-          return pair
+          self.headers << [ var.to_s.strip, val.to_s.strip ]
+          prev = self.headers.length - 1
         end
       end
-    end
-    nil
-  end
 
-  def set(var, val)
-    hdr = self.find(var) || self.add(var, '')
-    hdr[1] = val
-  end
+      def to_s
+        self.headers.map{ |pair| "#{pair[0]}: #{pair[1]}\r\n" }.join
+      end
 
-  def add(var, val)
-    self.headers << [var, val]
-    self.headers[-1]
-  end
+      def find(idx)
+        if (idx.class == ::Fixnum)
+          return self.headers[idx]
+        else
+          self.headers.each do |pair|
+            if (pair[0] == idx.to_s)
+              return pair
+            end
+          end
+        end
+        nil
+      end
 
-  def remove(idx)
-    if (idx.class == ::Fixnum)
-      self.headers.delete_at(idx)
-    else
-      self.headers.each_index do |i|
-        pair = self.headers[i]
-        if (pair[0] == idx.to_s)
-          self.headers.delete_at(i)
+      def set(var, val)
+        hdr = self.find(var) || self.add(var, '')
+        hdr[1] = val
+      end
+
+      def add(var, val)
+        self.headers << [var, val]
+        self.headers[-1]
+      end
+
+      def remove(idx)
+        if (idx.class == ::Fixnum)
+          self.headers.delete_at(idx)
+        else
+          self.headers.each_index do |i|
+            pair = self.headers[i]
+            if (pair[0] == idx.to_s)
+              self.headers.delete_at(i)
+            end
+          end
         end
       end
+
     end
   end
-
 end
-end
-end
-

--- a/lib/nexpose/rexlite/mime/header.rb
+++ b/lib/nexpose/rexlite/mime/header.rb
@@ -1,0 +1,77 @@
+# -*- coding: binary -*-
+module Rexlite
+module MIME
+class Header
+
+  attr_accessor :headers
+
+  def initialize(data='')
+    self.headers = []
+    parse(data)
+  end
+
+  def parse(data)
+    prev = nil
+    data.gsub("\r", '').split("\n").each do |line|
+
+      # Handle header folding
+      if (line =~ /^\s+/)
+        # Ignore if there is no previous header
+        next if not prev
+        next if not self.headers[prev]
+        self.headers[prev][1] << line.strip
+        next
+      end
+
+      var, val = line.split(':', 2)
+      next if val.nil?
+
+      self.headers << [ var.to_s.strip, val.to_s.strip ]
+      prev = self.headers.length - 1
+    end
+  end
+
+  def to_s
+    self.headers.map{ |pair| "#{pair[0]}: #{pair[1]}\r\n" }.join
+  end
+
+  def find(idx)
+    if (idx.class == ::Fixnum)
+      return self.headers[idx]
+    else
+      self.headers.each do |pair|
+        if (pair[0] == idx.to_s)
+          return pair
+        end
+      end
+    end
+    nil
+  end
+
+  def set(var, val)
+    hdr = self.find(var) || self.add(var, '')
+    hdr[1] = val
+  end
+
+  def add(var, val)
+    self.headers << [var, val]
+    self.headers[-1]
+  end
+
+  def remove(idx)
+    if (idx.class == ::Fixnum)
+      self.headers.delete_at(idx)
+    else
+      self.headers.each_index do |i|
+        pair = self.headers[i]
+        if (pair[0] == idx.to_s)
+          self.headers.delete_at(i)
+        end
+      end
+    end
+  end
+
+end
+end
+end
+

--- a/lib/nexpose/rexlite/mime/message.rb
+++ b/lib/nexpose/rexlite/mime/message.rb
@@ -1,0 +1,162 @@
+# -*- coding: binary -*-
+module Rexlite
+module MIME
+class Message
+
+  require 'nexpose/rexlite/mime/header'
+  require 'nexpose/rexlite/mime/part'
+  require 'nexpose/rexlite/mime/encoding'
+
+  include Rexlite::MIME::Encoding
+
+  attr_accessor :header, :parts, :bound, :content
+
+
+  def initialize(data=nil)
+    self.header = Rexlite::MIME::Header.new
+    self.parts  = []
+    self.bound  = "_Part_#{rand(1024)}_#{rand(0xffffffff)}_#{rand(0xffffffff)}"
+    self.content = ''
+    if data
+      head,body = data.split(/\r?\n\r?\n/, 2)
+
+      self.header.parse(head)
+      ctype = self.header.find('Content-Type')
+
+      if ctype && ctype[1] && ctype[1] =~ /multipart\/mixed;\s*boundary="?([A-Za-z0-9'\(\)\+\_,\-\.\/:=\?^\s]+)"?/
+        self.bound = $1
+        chunks = body.to_s.split(/--#{self.bound}(--)?\r?\n/)
+        self.content = chunks.shift.to_s.gsub(/\s+$/, '')
+        self.content << "\r\n" unless self.content.empty?
+
+        chunks.each do |chunk|
+          break if chunk == "--"
+          head,body = chunk.split(/\r?\n\r?\n/, 2)
+          part = Rexlite::MIME::Part.new
+          part.header.parse(head)
+          part.content = body.gsub(/\s+$/, '')
+          self.parts << part
+        end
+      else
+        self.content = body.to_s.gsub(/\s+$/, '') + "\r\n"
+      end
+    end
+  end
+
+  def to
+    (self.header.find('To') || [nil, nil])[1]
+  end
+
+  def to=(val)
+    self.header.set("To", val)
+  end
+
+  def from=(val)
+    self.header.set("From", val)
+  end
+
+  def from
+    (self.header.find('From') || [nil, nil])[1]
+  end
+
+  def subject=(val)
+    self.header.set("Subject", val)
+  end
+
+  def subject
+    (self.header.find('Subject') || [nil, nil])[1]
+  end
+
+  def mime_defaults
+    self.header.set("MIME-Version", "1.0")
+    self.header.set("Content-Type", "multipart/mixed; boundary=\"#{self.bound}\"")
+    self.header.set("Subject", '') # placeholder
+    self.header.set("Date", Time.now.strftime("%a,%e %b %Y %H:%M:%S %z"))
+    self.header.set("Message-ID",
+      "<"+
+      rand_text_alphanumeric(rand(20)+40)+
+      "@"+
+      rand_text_alpha(rand(20)+3)+
+      ">"
+    )
+    self.header.set("From", '')    # placeholder
+    self.header.set("To", '')      # placeholder
+  end
+
+  def rand_text_alphanumeric(len, bad='')
+    foo = []
+    foo += ('A' .. 'Z').to_a
+    foo += ('a' .. 'z').to_a
+    foo += ('0' .. '9').to_a
+    rand_base(len, bad, *foo )
+  end
+
+  def rand_text_alpha(len, bad='')
+    foo = []
+    foo += ('A' .. 'Z').to_a
+    foo += ('a' .. 'z').to_a
+    rand_base(len, bad, *foo )
+  end
+
+  def add_part(data='', content_type='text/plain', transfer_encoding="8bit", content_disposition=nil)
+    part = Rexlite::MIME::Part.new
+
+    if content_disposition
+      part.header.set("Content-Disposition", content_disposition)
+    end
+
+    part.header.set("Content-Type", content_type) if content_type
+
+    if transfer_encoding
+      part.header.set("Content-Transfer-Encoding", transfer_encoding)
+    end
+
+    part.content = data
+    self.parts << part
+    part
+  end
+
+  def add_part_attachment(data, name)
+    self.add_part(
+      encode_base64(data, "\r\n"),
+      "application/octet-stream; name=\"#{name}\"",
+      "base64",
+      "attachment; filename=\"#{name}\""
+    )
+  end
+
+
+  def add_part_inline_attachment(data, name)
+    self.add_part(
+      encode_base64(data, "\r\n"),
+      "application/octet-stream; name=\"#{name}\"",
+      "base64",
+      "inline; filename=\"#{name}\""
+    )
+  end
+
+  def encode_base64(str, delim='')
+    [str.to_s].pack("m").gsub(/\s+/, delim)
+  end
+
+
+  def to_s
+    header_string = self.header.to_s
+
+    msg = header_string.empty? ? '' : force_crlf(self.header.to_s + "\r\n")
+    msg << force_crlf(self.content + "\r\n") unless self.content.empty?
+
+    self.parts.each do |part|
+      msg << force_crlf("--" + self.bound + "\r\n")
+      msg << part.to_s
+    end
+
+    msg << force_crlf("--" + self.bound + "--\r\n") if self.parts.length > 0
+
+    msg
+  end
+
+end
+end
+end
+

--- a/lib/nexpose/rexlite/mime/message.rb
+++ b/lib/nexpose/rexlite/mime/message.rb
@@ -1,162 +1,161 @@
 # -*- coding: binary -*-
 module Rexlite
-module MIME
-class Message
+  module MIME
+    class Message
 
-  require 'nexpose/rexlite/mime/header'
-  require 'nexpose/rexlite/mime/part'
-  require 'nexpose/rexlite/mime/encoding'
+      require 'nexpose/rexlite/mime/header'
+      require 'nexpose/rexlite/mime/part'
+      require 'nexpose/rexlite/mime/encoding'
 
-  include Rexlite::MIME::Encoding
+      include Rexlite::MIME::Encoding
 
-  attr_accessor :header, :parts, :bound, :content
+      attr_accessor :header, :parts, :bound, :content
 
 
-  def initialize(data=nil)
-    self.header = Rexlite::MIME::Header.new
-    self.parts  = []
-    self.bound  = "_Part_#{rand(1024)}_#{rand(0xffffffff)}_#{rand(0xffffffff)}"
-    self.content = ''
-    if data
-      head,body = data.split(/\r?\n\r?\n/, 2)
+      def initialize(data=nil)
+        self.header = Rexlite::MIME::Header.new
+        self.parts  = []
+        self.bound  = "_Part_#{rand(1024)}_#{rand(0xffffffff)}_#{rand(0xffffffff)}"
+        self.content = ''
+        if data
+          head,body = data.split(/\r?\n\r?\n/, 2)
 
-      self.header.parse(head)
-      ctype = self.header.find('Content-Type')
+          self.header.parse(head)
+          ctype = self.header.find('Content-Type')
 
-      if ctype && ctype[1] && ctype[1] =~ /multipart\/mixed;\s*boundary="?([A-Za-z0-9'\(\)\+\_,\-\.\/:=\?^\s]+)"?/
-        self.bound = $1
-        chunks = body.to_s.split(/--#{self.bound}(--)?\r?\n/)
-        self.content = chunks.shift.to_s.gsub(/\s+$/, '')
-        self.content << "\r\n" unless self.content.empty?
+          if ctype && ctype[1] && ctype[1] =~ /multipart\/mixed;\s*boundary="?([A-Za-z0-9'\(\)\+\_,\-\.\/:=\?^\s]+)"?/
+            self.bound = $1
+            chunks = body.to_s.split(/--#{self.bound}(--)?\r?\n/)
+            self.content = chunks.shift.to_s.gsub(/\s+$/, '')
+            self.content << "\r\n" unless self.content.empty?
 
-        chunks.each do |chunk|
-          break if chunk == "--"
-          head,body = chunk.split(/\r?\n\r?\n/, 2)
-          part = Rexlite::MIME::Part.new
-          part.header.parse(head)
-          part.content = body.gsub(/\s+$/, '')
-          self.parts << part
+            chunks.each do |chunk|
+              break if chunk == "--"
+              head,body = chunk.split(/\r?\n\r?\n/, 2)
+              part = Rexlite::MIME::Part.new
+              part.header.parse(head)
+              part.content = body.gsub(/\s+$/, '')
+              self.parts << part
+            end
+          else
+            self.content = body.to_s.gsub(/\s+$/, '') + "\r\n"
+          end
         end
-      else
-        self.content = body.to_s.gsub(/\s+$/, '') + "\r\n"
       end
+
+      def to
+        (self.header.find('To') || [nil, nil])[1]
+      end
+
+      def to=(val)
+        self.header.set("To", val)
+      end
+
+      def from=(val)
+        self.header.set("From", val)
+      end
+
+      def from
+        (self.header.find('From') || [nil, nil])[1]
+      end
+
+      def subject=(val)
+        self.header.set("Subject", val)
+      end
+
+      def subject
+        (self.header.find('Subject') || [nil, nil])[1]
+      end
+
+      def mime_defaults
+        self.header.set("MIME-Version", "1.0")
+        self.header.set("Content-Type", "multipart/mixed; boundary=\"#{self.bound}\"")
+        self.header.set("Subject", '') # placeholder
+        self.header.set("Date", Time.now.strftime("%a,%e %b %Y %H:%M:%S %z"))
+        self.header.set("Message-ID",
+                        "<"+
+                        rand_text_alphanumeric(rand(20)+40)+
+                        "@"+
+                        rand_text_alpha(rand(20)+3)+
+                        ">"
+                        )
+        self.header.set("From", '')    # placeholder
+        self.header.set("To", '')      # placeholder
+      end
+
+      def rand_text_alphanumeric(len, bad='')
+        foo = []
+        foo += ('A' .. 'Z').to_a
+        foo += ('a' .. 'z').to_a
+        foo += ('0' .. '9').to_a
+        rand_base(len, bad, *foo )
+      end
+
+      def rand_text_alpha(len, bad='')
+        foo = []
+        foo += ('A' .. 'Z').to_a
+        foo += ('a' .. 'z').to_a
+        rand_base(len, bad, *foo )
+      end
+
+      def add_part(data='', content_type='text/plain', transfer_encoding="8bit", content_disposition=nil)
+        part = Rexlite::MIME::Part.new
+
+        if content_disposition
+          part.header.set("Content-Disposition", content_disposition)
+        end
+
+        part.header.set("Content-Type", content_type) if content_type
+
+        if transfer_encoding
+          part.header.set("Content-Transfer-Encoding", transfer_encoding)
+        end
+
+        part.content = data
+        self.parts << part
+        part
+      end
+
+      def add_part_attachment(data, name)
+        self.add_part(
+          encode_base64(data, "\r\n"),
+          "application/octet-stream; name=\"#{name}\"",
+          "base64",
+          "attachment; filename=\"#{name}\""
+        )
+      end
+
+
+      def add_part_inline_attachment(data, name)
+        self.add_part(
+          encode_base64(data, "\r\n"),
+          "application/octet-stream; name=\"#{name}\"",
+          "base64",
+          "inline; filename=\"#{name}\""
+        )
+      end
+
+      def encode_base64(str, delim='')
+        [str.to_s].pack("m").gsub(/\s+/, delim)
+      end
+
+
+      def to_s
+        header_string = self.header.to_s
+
+        msg = header_string.empty? ? '' : force_crlf(self.header.to_s + "\r\n")
+        msg << force_crlf(self.content + "\r\n") unless self.content.empty?
+
+        self.parts.each do |part|
+          msg << force_crlf("--" + self.bound + "\r\n")
+          msg << part.to_s
+        end
+
+        msg << force_crlf("--" + self.bound + "--\r\n") if self.parts.length > 0
+
+        msg
+      end
+
     end
   end
-
-  def to
-    (self.header.find('To') || [nil, nil])[1]
-  end
-
-  def to=(val)
-    self.header.set("To", val)
-  end
-
-  def from=(val)
-    self.header.set("From", val)
-  end
-
-  def from
-    (self.header.find('From') || [nil, nil])[1]
-  end
-
-  def subject=(val)
-    self.header.set("Subject", val)
-  end
-
-  def subject
-    (self.header.find('Subject') || [nil, nil])[1]
-  end
-
-  def mime_defaults
-    self.header.set("MIME-Version", "1.0")
-    self.header.set("Content-Type", "multipart/mixed; boundary=\"#{self.bound}\"")
-    self.header.set("Subject", '') # placeholder
-    self.header.set("Date", Time.now.strftime("%a,%e %b %Y %H:%M:%S %z"))
-    self.header.set("Message-ID",
-      "<"+
-      rand_text_alphanumeric(rand(20)+40)+
-      "@"+
-      rand_text_alpha(rand(20)+3)+
-      ">"
-    )
-    self.header.set("From", '')    # placeholder
-    self.header.set("To", '')      # placeholder
-  end
-
-  def rand_text_alphanumeric(len, bad='')
-    foo = []
-    foo += ('A' .. 'Z').to_a
-    foo += ('a' .. 'z').to_a
-    foo += ('0' .. '9').to_a
-    rand_base(len, bad, *foo )
-  end
-
-  def rand_text_alpha(len, bad='')
-    foo = []
-    foo += ('A' .. 'Z').to_a
-    foo += ('a' .. 'z').to_a
-    rand_base(len, bad, *foo )
-  end
-
-  def add_part(data='', content_type='text/plain', transfer_encoding="8bit", content_disposition=nil)
-    part = Rexlite::MIME::Part.new
-
-    if content_disposition
-      part.header.set("Content-Disposition", content_disposition)
-    end
-
-    part.header.set("Content-Type", content_type) if content_type
-
-    if transfer_encoding
-      part.header.set("Content-Transfer-Encoding", transfer_encoding)
-    end
-
-    part.content = data
-    self.parts << part
-    part
-  end
-
-  def add_part_attachment(data, name)
-    self.add_part(
-      encode_base64(data, "\r\n"),
-      "application/octet-stream; name=\"#{name}\"",
-      "base64",
-      "attachment; filename=\"#{name}\""
-    )
-  end
-
-
-  def add_part_inline_attachment(data, name)
-    self.add_part(
-      encode_base64(data, "\r\n"),
-      "application/octet-stream; name=\"#{name}\"",
-      "base64",
-      "inline; filename=\"#{name}\""
-    )
-  end
-
-  def encode_base64(str, delim='')
-    [str.to_s].pack("m").gsub(/\s+/, delim)
-  end
-
-
-  def to_s
-    header_string = self.header.to_s
-
-    msg = header_string.empty? ? '' : force_crlf(self.header.to_s + "\r\n")
-    msg << force_crlf(self.content + "\r\n") unless self.content.empty?
-
-    self.parts.each do |part|
-      msg << force_crlf("--" + self.bound + "\r\n")
-      msg << part.to_s
-    end
-
-    msg << force_crlf("--" + self.bound + "--\r\n") if self.parts.length > 0
-
-    msg
-  end
-
 end
-end
-end
-

--- a/lib/nexpose/rexlite/mime/part.rb
+++ b/lib/nexpose/rexlite/mime/part.rb
@@ -1,50 +1,50 @@
 # -*- coding: binary -*-
 module Rexlite
-module MIME
-class Part
+  module MIME
+    class Part
 
-  require 'nexpose/rexlite/mime/header'
-  require 'nexpose/rexlite/mime/encoding'
+      require 'nexpose/rexlite/mime/header'
+      require 'nexpose/rexlite/mime/encoding'
 
-  include Rexlite::MIME::Encoding
+      include Rexlite::MIME::Encoding
 
-  attr_accessor :header, :content
+      attr_accessor :header, :content
 
-  def initialize
-    self.header = Rexlite::MIME::Header.new
-    self.content = ''
+      def initialize
+        self.header = Rexlite::MIME::Header.new
+        self.content = ''
+      end
+
+      def to_s
+        self.header.to_s + "\r\n" + content_encoded + "\r\n"
+      end
+
+      # Returns the part content with any necessary encoding or transformation
+      # applied.
+      #
+      # @return [String] Content with encoding or transformations applied.
+      def content_encoded
+        binary_content? ? content : force_crlf(content)
+      end
+
+      # Answers if the part content is binary.
+      #
+      # @return [Boolean] true if the part content is binary, false otherwise.
+      def binary_content?
+        transfer_encoding && transfer_encoding == 'binary'
+      end
+
+      # Returns the Content-Transfer-Encoding of the part.
+      #
+      # @return [nil] if the part hasn't Content-Transfer-Encoding.
+      # @return [String] The Content-Transfer-Encoding or the part.
+      def transfer_encoding
+        h = header.find('Content-Transfer-Encoding')
+        return nil if h.nil?
+
+        h[1]
+      end
+
+    end
   end
-
-  def to_s
-    self.header.to_s + "\r\n" + content_encoded + "\r\n"
-  end
-
-  # Returns the part content with any necessary encoding or transformation
-  # applied.
-  #
-  # @return [String] Content with encoding or transformations applied.
-  def content_encoded
-    binary_content? ? content : force_crlf(content)
-  end
-
-  # Answers if the part content is binary.
-  #
-  # @return [Boolean] true if the part content is binary, false otherwise.
-  def binary_content?
-    transfer_encoding && transfer_encoding == 'binary'
-  end
-
-  # Returns the Content-Transfer-Encoding of the part.
-  #
-  # @return [nil] if the part hasn't Content-Transfer-Encoding.
-  # @return [String] The Content-Transfer-Encoding or the part.
-  def transfer_encoding
-    h = header.find('Content-Transfer-Encoding')
-    return nil if h.nil?
-
-    h[1]
-  end
-
-end
-end
 end

--- a/lib/nexpose/rexlite/mime/part.rb
+++ b/lib/nexpose/rexlite/mime/part.rb
@@ -1,0 +1,50 @@
+# -*- coding: binary -*-
+module Rexlite
+module MIME
+class Part
+
+  require 'nexpose/rexlite/mime/header'
+  require 'nexpose/rexlite/mime/encoding'
+
+  include Rexlite::MIME::Encoding
+
+  attr_accessor :header, :content
+
+  def initialize
+    self.header = Rexlite::MIME::Header.new
+    self.content = ''
+  end
+
+  def to_s
+    self.header.to_s + "\r\n" + content_encoded + "\r\n"
+  end
+
+  # Returns the part content with any necessary encoding or transformation
+  # applied.
+  #
+  # @return [String] Content with encoding or transformations applied.
+  def content_encoded
+    binary_content? ? content : force_crlf(content)
+  end
+
+  # Answers if the part content is binary.
+  #
+  # @return [Boolean] true if the part content is binary, false otherwise.
+  def binary_content?
+    transfer_encoding && transfer_encoding == 'binary'
+  end
+
+  # Returns the Content-Transfer-Encoding of the part.
+  #
+  # @return [nil] if the part hasn't Content-Transfer-Encoding.
+  # @return [String] The Content-Transfer-Encoding or the part.
+  def transfer_encoding
+    h = header.find('Content-Transfer-Encoding')
+    return nil if h.nil?
+
+    h[1]
+  end
+
+end
+end
+end

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -404,7 +404,7 @@ module Nexpose
     # @return [String] An empty string on success.
     #
     def import_scan(site_id, zip_file)
-      data = Rex::MIME::Message.new
+      data = Rexlite::MIME::Message.new
       data.add_part(site_id.to_s, nil, nil, 'form-data; name="siteid"')
       data.add_part(session_id, nil, nil, 'form-data; name="nexposeCCSessionID"')
       ::File.open(zip_file, 'rb') do |scan|

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -385,11 +385,7 @@ module Nexpose
       end
     end
 
-    # Import scan data into a site. WARNING: Experimental!
-    #
-    # This code currently depends on a gem not in the gemspec. In order to use
-    # this method, you will need to add the following line to your script:
-    #   require 'rest-client'
+    # Import scan data into a site.
     #
     # This method is designed to work with export_scan to migrate scan data
     # from one console to another. This method will import the data as if run

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
   s.platform              = 'ruby'
 
-  s.add_runtime_dependency('rex', '= 2.0.8')
-
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')
   s.add_development_dependency('simplecov', '~> 0.9.1')


### PR DESCRIPTION
Removes Rex as a dependency from nexpose-client altogether. The Rex::MIME module has been incorporated into nexpose-client under the Rexlite::MIME module to avoid namespace collisions.

At this time Rex::MIME was the only part of Rex that nexpose-client depended on. A few methods of Rex::Text were also pulled into the consuming classes in Rexlite::MIME.

Rex::MIME::Message was used by the `Connection#import_scan` and `AdhocReportConfig#generate` methods.

cc @sgreen-r7 @hdm @jhart-r7

All of the files pulled over are under the BSD 3-clause license in the Rex project I believe.