### PR TITLE
removing additional deprecated scan template methods

### DIFF
--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -321,12 +321,6 @@ module Nexpose
       checks ? checks.elements.to_a('VulnCategory').map { |c| c.attributes['name'] } : []
     end
 
-    # @deprecated Use {#enabled_checks_by_category} instead
-    def checks_by_category
-      warn "[DEPRECATED] Use #{self.class}#enabled_checks_by_category instead of #{self.class}##{__method__}"
-      enabled_checks_by_category
-    end
-
     # Get a list of the check categories enabled for this scan template.
     #
     # @return [Array[String]] List of enabled categories.
@@ -368,12 +362,6 @@ module Nexpose
     def disabled_checks_by_type
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks/Disabled')
       checks ? checks.elements.to_a('CheckType').map { |c| c.attributes['name'] } : []
-    end
-
-    # @deprecated Use {#enabled_checks_by_type} instead
-    def checks_by_type
-      warn "[DEPRECATED] Use #{self.class}#enabled_checks_by_type instead of #{self.class}##{__method__}"
-      enabled_checks_by_type
     end
 
     # Get a list of the check types enabled for this scan template.
@@ -428,12 +416,6 @@ module Nexpose
       checks = REXML::XPath.first(@xml, '//VulnerabilityChecks')
       checks.elements.delete("Disabled/#{elem}[@name='#{check}']")
       checks.elements.delete("Enabled/#{elem}[@name='#{check}']")
-    end
-
-    # @deprecated Use {#enabled_vuln_checks} instead
-    def vuln_checks
-      warn "[DEPRECATED] Use #{self.class}#enabled_vuln_checks instead of #{self.class}##{__method__}"
-      enabled_vuln_checks
     end
 
     # Get a list of the individual vuln checks enabled for this scan template.

--- a/spec/nexpose/scan_template_spec.rb
+++ b/spec/nexpose/scan_template_spec.rb
@@ -9,7 +9,6 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability checks' do
         expect(subject.enabled_vuln_checks).to be_empty
-        expect(subject.vuln_checks).to be_empty
       end
     end
     context 'when checks are enabled' do
@@ -18,7 +17,6 @@ describe Nexpose::ScanTemplate do
           subject.enable_vuln_check(thing)
         end
         expect(subject.enabled_vuln_checks).to eq(random_things)
-        expect(subject.vuln_checks).to eq(random_things)
       end
     end
     context 'when checks are disabled' do
@@ -35,7 +33,6 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability categories' do
         expect(subject.enabled_checks_by_category).to be_empty
-        expect(subject.checks_by_category).to be_empty
       end
     end
     context 'when categories are enabled' do
@@ -44,7 +41,6 @@ describe Nexpose::ScanTemplate do
           subject.enable_checks_by_category(thing)
         end
         expect(subject.enabled_checks_by_category).to eq(random_things)
-        expect(subject.checks_by_category).to eq(random_things)
       end
     end
     context 'when categories are disabled' do
@@ -61,7 +57,6 @@ describe Nexpose::ScanTemplate do
     context 'by default' do
       it 'returns no enabled vulnerability types' do
         expect(subject.enabled_checks_by_type).to be_empty
-        expect(subject.checks_by_type).to be_empty
       end
     end
     context 'when types are enabled' do
@@ -70,7 +65,6 @@ describe Nexpose::ScanTemplate do
           subject.enable_checks_by_type(thing)
         end
         expect(subject.enabled_checks_by_type).to eq(random_things)
-        expect(subject.checks_by_type).to eq(random_things)
       end
     end
     context 'when types are disabled' do


### PR DESCRIPTION
Removing the following deprecated methods:

`ScanTemplate.checks_by_category`
`ScanTemplate.checks_by_type`
`ScanTemplate.vuln_checks`