### PR TITLE
Make HostOrIP#convert more flexible on IP address range input

### DIFF
--- a/lib/nexpose/util.rb
+++ b/lib/nexpose/util.rb
@@ -50,7 +50,7 @@ module Nexpose
     # @return [IPRange|HostName] Valid class, if it can be converted.
     #
     def convert(asset)
-      ips = asset.split(' - ')
+      ips = asset.split('-').map(&:strip)
       IPAddr.new(ips[0])
       IPAddr.new(ips[1]) if ips[1]
       IPRange.new(ips[0], ips[1])

--- a/spec/nexpose/util/host_or_ip_spec.rb
+++ b/spec/nexpose/util/host_or_ip_spec.rb
@@ -5,7 +5,7 @@ describe Nexpose::HostOrIP do
 
   describe '.convert' do
     context 'with a fully qualified domain name' do
-      let(:asset) { asset = 'nexpose.local' }
+      let(:asset) { 'nexpose.local' }
 
       it 'returns a HostName' do
         observed = subject.convert(asset)
@@ -14,7 +14,7 @@ describe Nexpose::HostOrIP do
     end
 
     context 'with a hostname' do
-      let(:asset) { asset = 'target-host' }
+      let(:asset) { 'target-host' }
 
       it 'returns a HostName' do
         observed = subject.convert(asset)
@@ -23,8 +23,7 @@ describe Nexpose::HostOrIP do
     end
 
     context 'with an IP address' do
-      let(:asset) { asset = '192.168.1.1' }
-
+      let(:asset) { '192.168.1.1' }
 
       it 'returns an IPRange' do
         observed = subject.convert(asset)
@@ -33,8 +32,7 @@ describe Nexpose::HostOrIP do
     end
 
     context 'with an IP address range in CIDR format' do
-      let(:asset) { asset = '192.168.1.0/24' }
-
+      let(:asset) { '192.168.1.0/24' }
 
       it 'returns an IPRange' do
         observed = subject.convert(asset)
@@ -43,8 +41,7 @@ describe Nexpose::HostOrIP do
     end
 
     context 'with an IP address range without whitespace' do
-      let(:asset) { asset = '192.168.1.0-192.168.1.255' }
-
+      let(:asset) { '192.168.1.0-192.168.1.255' }
 
       it 'returns an IPRange' do
         observed = subject.convert(asset)
@@ -53,8 +50,7 @@ describe Nexpose::HostOrIP do
     end
 
     context 'with an IP address range with whitespace' do
-      let(:asset) { asset = '192.168.1.0   -   192.168.1.255' }
-
+      let(:asset) { '192.168.1.0   -   192.168.1.255' }
 
       it 'returns an IPRange' do
         observed = subject.convert(asset)

--- a/spec/nexpose/util/host_or_ip_spec.rb
+++ b/spec/nexpose/util/host_or_ip_spec.rb
@@ -32,8 +32,28 @@ describe Nexpose::HostOrIP do
       end
     end
 
-    context 'with an IP address range' do
+    context 'with an IP address range in CIDR format' do
       let(:asset) { asset = '192.168.1.0/24' }
+
+
+      it 'returns an IPRange' do
+        observed = subject.convert(asset)
+        expect(observed).to be_a(Nexpose::IPRange)
+      end
+    end
+
+    context 'with an IP address range without whitespace' do
+      let(:asset) { asset = '192.168.1.0-192.168.1.255' }
+
+
+      it 'returns an IPRange' do
+        observed = subject.convert(asset)
+        expect(observed).to be_a(Nexpose::IPRange)
+      end
+    end
+
+    context 'with an IP address range with whitespace' do
+      let(:asset) { asset = '192.168.1.0   -   192.168.1.255' }
 
 
       it 'returns an IPRange' do


### PR DESCRIPTION
Had discussions with 2 different people today where this change would be very useful to them, so figured I'd throw it in here so they don't have to do it in their own scripts.

As you can see in the new tests, IP ranges are now converted with or without whitespace. As long as there is a hyphen (`-`) it should correctly make a range regardless of whitespace.