### PR TITLE
Use latest minor versions of Ruby in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
-  - jruby
+  - ruby-head
+  - jruby-9.0.5.0
+  - jruby-head
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,31 @@ rvm:
   - 2.3.1
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-head
+jdk:
+  - oraclejdk8
+  - openjdk8
+matrix:
+  exclude:
+    - rvm: 2.1.5
+      jdk: openjdk8
+    - rvm: 2.1.5
+      jdk: oraclejdk8
+    - rvm: 2.1.9
+      jdk: openjdk8
+    - rvm: 2.1.9
+      jdk: oraclejdk8
+    - rvm: 2.2.5
+      jdk: openjdk8
+    - rvm: 2.2.5
+      jdk: oraclejdk8
+    - rvm: 2.3.1
+      jdk: openjdk8
+    - rvm: 2.3.1
+      jdk: oraclejdk8
+    - rvm: ruby-head
+      jdk: openjdk8
+    - rvm: ruby-head
+      jdk: oraclejdk8
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,6 @@ rvm:
   - jruby-9.0.5.0
 jdk:
   - oraclejdk8
-  - openjdk8
-matrix:
-  exclude:
-    - rvm: 2.1.5
-      jdk: openjdk8
-    - rvm: 2.1.5
-      jdk: oraclejdk8
-    - rvm: 2.1.9
-      jdk: openjdk8
-    - rvm: 2.1.9
-      jdk: oraclejdk8
-    - rvm: 2.2.5
-      jdk: openjdk8
-    - rvm: 2.2.5
-      jdk: oraclejdk8
-    - rvm: 2.3.1
-      jdk: openjdk8
-    - rvm: 2.3.1
-      jdk: oraclejdk8
-    - rvm: ruby-head
-      jdk: openjdk8
-    - rvm: ruby-head
-      jdk: oraclejdk8
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.5
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - jruby
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.5
-  - 2.1
-  - 2.2
-  - 2.3
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - jruby
 script: bundle exec rspec --color --format=documentation
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.5
-  - 2.1
-  - 2.2
-  - 2.3
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.5
-  - 2.2.0
+  - 2.1
+  - 2.2
+  - 2.3
 script: bundle exec rspec --color --format=documentation
 addons:
   code_climate:


### PR DESCRIPTION
The idea here is to have more realistic coverage in case we end up doing something that can break on a specific, newer ruby version. I'm keeping 2.1.5 in addition to 2.1.latest to ensure we maintain a minimum compatible version of Ruby (for now).