### PR TITLE
Allow import scan to return scan ID when available

### DIFF
--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -461,7 +461,7 @@ module Nexpose
       response = http.request(post)
       case response
       when Net::HTTPOK
-        response.body
+        response.body.empty? ? response.body : response.body.to_i
       when Net::HTTPUnauthorized
         raise Nexpose::PermissionError.new(response)
       else

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -440,7 +440,7 @@ module Nexpose
     #
     # @param [Fixnum] site_id Site ID of the site to import the scan into.
     # @param [String] zip_file Path to a previously exported scan archive.
-    # @return [String] An empty string on success.
+    # @return [Fixnum] The scan ID on success.
     #
     def import_scan(site_id, zip_file)
       data = Rexlite::MIME::Message.new


### PR DESCRIPTION
Resolves #208 

This will return a scan ID as an integer if it is present in the response body. The scan ID will be returned from the import scan request in an upcoming release of Nexpose (6.2.6).

This shouldn't break any existing scripts since no one ever relied on the return value (it would raise an exception on failure). For pre-6.2.6 versions of Nexpose, an empty string will still be returned.

This is technically a breaking change to the API due to return type changing, though.