### PR TITLE
Increase REXML::Security.entity_expansion_text_limit

### DIFF
--- a/lib/nexpose.rb
+++ b/lib/nexpose.rb
@@ -110,6 +110,10 @@ require 'nexpose/maint'
 require 'nexpose/version'
 require 'nexpose/wait'
 
+# Double the size of the default limit,
+# to work around large vuln content.
+REXML::Security.entity_expansion_text_limit = 20_000
+
 module Nexpose
 
   # Echos the last XML API request and response for the specified object.  (Useful for debugging)


### PR DESCRIPTION
When parsing vuln details with a large amount of content, we were seeing the ``entity expansion has grown too large (RuntimeError)`` error. 

Example Large Vuln: ``nsc.vuln_details('linuxrpm-rhsa-2014-0798')``

Note, [there is a fixed CVE from 2013 around this value](https://www.ruby-lang.org/en/news/2013/02/22/rexml-dos-2013-02-22/), which is why we did not 'significantly' increase the size. 