### PR TITLE
Use a different method for getting engine versions

### DIFF
--- a/lib/nexpose/manage.rb
+++ b/lib/nexpose/manage.rb
@@ -44,22 +44,10 @@ module Nexpose
     end
 
     # Obtain the version information for each scan engine.
-    # Includes Product, Content, and Java versions.
+    # Includes dates and ids for Product and Content versions.
     #
     def engine_versions
-      info = console_command('version engines')
-      versions = []
-      engines = info.sub('VERSION INFORMATION\n', '').split(/\n\n/)
-      engines.each do |eng|
-        engdata = {}
-        eng.split(/\n/).each do |kv|
-          key, value = kv.split(/:\s*/)
-          key = key.sub('Local Engine  ', '').sub('Remote Engine ', '')
-          engdata[key] = value
-        end
-        versions << engdata
-      end
-      versions
+      JSON.parse(AJAX.post(self, "/data/engines"))['records']
     end
 
     # Induce the application to retrieve required updates and restart


### PR DESCRIPTION
The previous method of parsing the output of the "version engines" console command doesn't always work. The console command sometimes doesn't return data. This AJAX post method is what the web UI uses to get the engine data. It returns an array of engine data hash objects.