### PR TITLE
#233: Fixed parsing of completed asset response to use correct asset ID

### DIFF
--- a/lib/nexpose/device.rb
+++ b/lib/nexpose/device.rb
@@ -208,7 +208,7 @@ module Nexpose
     # object.
     def self.parse_json(json)
       new do
-        @id = json['id'].to_i
+        @id = json['assetID'].to_i
         @ip = json['ipAddress']
         @host_name = json['hostName']
         @os = json['operatingSystem']


### PR DESCRIPTION
Fix for [#233](https://github.com/rapid7/nexpose-client/issues/233). The JSON parsing for `CompletedAsset` was parsing the node ID from the response into the `id` field rather than the asset ID. If the caller used this to perform a request to list asset details, it would lead to using the wrong identifier (and result in failed requests with permissions issues).