### PR TITLE
Revert changes to maintenance command URIs

### DIFF
--- a/lib/nexpose/maint.rb
+++ b/lib/nexpose/maint.rb
@@ -26,7 +26,7 @@ module Nexpose
                      'cmd' => 'backup',
                      'platform_independent' => platform_independent,
                      'targetTask' => 'backupRestore' }
-      xml = AJAX.form_post(self, '/data/maintenance/command', parameters)
+      xml = AJAX.form_post(self, '/admin/global/maintenance/maintCmd.txml', parameters)
       if !!(xml =~ /succeded="true"/)
         _maintenance_restart
       end
@@ -51,7 +51,7 @@ module Nexpose
       parameters['cleanup'] = 1 if clean_up
       parameters['compress'] = 1 if compress
       parameters['reindex'] = 1 if reindex
-      xml = AJAX.form_post(self, '/data/maintenance/command', parameters)
+      xml = AJAX.form_post(self, '/admin/global/maintenance/maintCmd.txml', parameters)
       if !!(xml =~ /succeded="true"/)
         _maintenance_restart
       end
@@ -61,7 +61,7 @@ module Nexpose
       parameters = { 'cancelAllTasks' => false,
                      'cmd' => 'restartServer',
                      'targetTask' => 'maintModeHandler' }
-      xml = AJAX.form_post(self, '/data/maintenanceMode/command', parameters)
+      xml = AJAX.form_post(self, '/admin/global/maintenance/maintCmd.txml', parameters)
       !!(xml =~ /succeded="true"/)
     end
   end
@@ -103,7 +103,7 @@ module Nexpose
       parameters = { 'backupid' => @name,
                      'cmd' => 'restore',
                      'targetTask' => 'backupRestore' }
-      xml = AJAX.form_post(nsc, '/data/maintenance/command', parameters)
+      xml = AJAX.form_post(nsc, '/admin/global/maintenance/maintCmd.txml', parameters)
       if !!(xml =~ /succeded="true"/)
         nsc._maintenance_restart
       end
@@ -118,7 +118,7 @@ module Nexpose
       parameters = { 'backupid' => @name,
                      'cmd' => 'deleteBackup',
                      'targetTask' => 'backupRestore' }
-      xml = AJAX.form_post(nsc, '/data/maintenance/command', parameters)
+      xml = AJAX.form_post(nsc, '/admin/global/maintenance/maintCmd.txml', parameters)
       !!(xml =~ /succeded="true"/)
     end
 


### PR DESCRIPTION
Due to an unresolved defect in Nexpose, the current URIs for maintenance commands were not reliably processing requests. The old URIs still exist and are known to work, so use those like before.