### PR TITLE
Add Unique ID support to Asset and ExternalAsset

### DIFF
--- a/lib/nexpose/asset.rb
+++ b/lib/nexpose/asset.rb
@@ -268,7 +268,7 @@ module Nexpose
   # Unique system identifiers on an asset.
   #
   class UniqueIdentifier < APIObject
-    # User account name.
+    # The source name for the uniuqe identifier.
     attr_reader :source
     # Unique identifier of the user as determined by the asset (not Nexpose).
     attr_reader :id

--- a/lib/nexpose/asset.rb
+++ b/lib/nexpose/asset.rb
@@ -274,18 +274,19 @@ module Nexpose
     attr_reader :id
 
     def initialize(source = nil, id = nil)
-      @id, @source = id, source
+      @id = id
+      @source = source
     end
 
     def to_h
       { source: source,
-        id: id}
+        id: id }
     end
 
     def <=>(other)
       c = source <=> other.source
       return c unless c == 0
-      c = id <=> other.id
+      id <=> other.id
     end
 
     def ==(other)

--- a/lib/nexpose/asset.rb
+++ b/lib/nexpose/asset.rb
@@ -38,6 +38,8 @@ module Nexpose
     attr_reader :group_accounts
     # Files and directories that have been enumerated on the asset. [Lazy]
     attr_reader :files
+    # Unique system identifiers on the asset.
+    attr_accessor :unique_identifiers
 
     def initialize
       @addresses = []
@@ -47,7 +49,7 @@ module Nexpose
     # Load an asset from the provided console.
     #
     # @param [Connection] nsc Active connection to a Nexpose console.
-    # @param [String] id Unique identifier of an asset.
+    # @param [Fixnum] id Unique identifier of an asset.
     # @return [Asset] The requested asset, if found.
     #
     def self.load(nsc, id)
@@ -260,6 +262,38 @@ module Nexpose
 
     def eql?(other)
       name.eql?(other.name) && size.eql?(other.size) && directory.eql?(other.directory) && attributes.eql?(other.attributes)
+    end
+  end
+
+  # Unique system identifiers on an asset.
+  #
+  class UniqueIdentifier < APIObject
+    # User account name.
+    attr_reader :source
+    # Unique identifier of the user as determined by the asset (not Nexpose).
+    attr_reader :id
+
+    def initialize(source = nil, id = nil)
+      @id, @source = id, source
+    end
+
+    def to_h
+      { source: source,
+        id: id}
+    end
+
+    def <=>(other)
+      c = source <=> other.source
+      return c unless c == 0
+      c = id <=> other.id
+    end
+
+    def ==(other)
+      eql?(other)
+    end
+
+    def eql?(other)
+      source.eql?(other.source) && id.eql?(other.id)
     end
   end
 

--- a/lib/nexpose/external.rb
+++ b/lib/nexpose/external.rb
@@ -79,6 +79,8 @@ module Nexpose
       attr_accessor :groups
       # Files and directories on the asset.
       attr_accessor :files
+      # Unique system identifiers on the asset.
+      attr_accessor :unique_identifiers
       # A list of key-value attributes associated with the asset.
       attr_accessor :attributes
       # Asset-level vulnerabilities.
@@ -92,6 +94,7 @@ module Nexpose
         @users = []
         @groups = []
         @files = []
+        @unique_identifiers = []
         @vulnerabilities = []
       end
 
@@ -113,6 +116,7 @@ module Nexpose
           users: users.map(&:to_h),
           groups: groups.map(&:to_h),
           files: files.map(&:to_h),
+          unique_identifiers: unique_identifiers.map(&:to_h),
           vulnerabilities: vulnerabilities.map(&:to_h),
           attributes: Attributes.to_hash(attributes) }
       end

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')
   s.add_development_dependency('simplecov', '~> 0.9.1')
   s.add_development_dependency('rspec', '~> 3.2')
-  s.add_development_dependency('rubocop', '~> 0.29.0')
+  s.add_development_dependency('rubocop')
   s.add_development_dependency('webmock', '~> 1.20.4')
   s.add_development_dependency('vcr', '~> 2.9.3')
 end


### PR DESCRIPTION
This was previously hidden away in private test code, but I'm not sure why it wouldn't be in the public code.

I also removed the version restriction on rubocop because it caused me some issues with my dev environment.