### PR TITLE
Update Connection#download method to stream data

### DIFF
--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -94,7 +94,8 @@ module Nexpose
     end
 
     # Download a specific URL, typically a report.
-    # Include an optional file_name parameter to write the output to a file.
+    # Include an optional file_name parameter to stream the output to a file.
+    # Pass a block to get the response as it is returned from the server
     #
     # Note: XML and HTML reports have charts not downloaded by this method.
     #       Would need to do something more sophisticated to grab
@@ -102,16 +103,29 @@ module Nexpose
     def download(url, file_name = nil)
       return nil if url.nil? or url.empty?
       uri = URI.parse(url)
-      http = Net::HTTP.new(@host, @port)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE # XXX: security issue
+      
       headers = {'Cookie' => "nexposeCCSessionID=#{@session_id}"}
-      resp = http.get(uri.to_s, headers)
-
-      if file_name
-        ::File.open(file_name, 'wb') { |file| file.write(resp.body) }
-      else
-        resp.body
+      
+      Net::HTTP.start(@host, @port, 
+                      use_ssl: true, 
+                      verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+        request = Net::HTTP::Get.new(uri.to_s, headers)
+        
+        http.request(request) do |response|
+          if filename
+            File.open(filename, 'wb') do |f|
+              response.read_body do |chunk|
+                f.write chunk
+              end
+            end
+          elsif block_given?
+            response.read_body do |chunk|
+              yield chunk
+            end
+          else
+            return response.body
+          end
+        end
       end
     end
   end

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -103,14 +103,14 @@ module Nexpose
     def download(url, file_name = nil)
       return nil if url.nil? or url.empty?
       uri = URI.parse(url)
-      
+
       headers = {'Cookie' => "nexposeCCSessionID=#{@session_id}"}
-      
-      Net::HTTP.start(@host, @port, 
-                      use_ssl: true, 
+
+      Net::HTTP.start(@host, @port,
+                      use_ssl: true,
                       verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
         request = Net::HTTP::Get.new(uri.to_s, headers)
-        
+
         http.request(request) do |response|
           if filename
             File.open(filename, 'wb') do |f|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The download method waits for the entire response body before returning the data to the caller or storing it into a file. This change implements streaming the request to accommodate large file/report downloads. 
## Description
<!--- Describe your changes in detail -->
Streams the HTTP Response body to a file, allows for the caller to pass in a block, and maintains the default behaviour of the method to avoid needing changes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was seeing weird timeout and Errno::EINVAL issues that were thrown when large (4GB) report downloads were requested. This addresses those.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Used to download 100 reports of sizes ranging from 5KB to 5GB and successfully completed all of them.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No impact to existing code

## Screenshots (if appropriate):
<!--- Drag-and-drop any relevant screenshots here, if applicable. -->

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly (if changes are required).
- [ ] ~~I have added tests to cover my changes.~~
- [X] All new and existing tests passed.

Large file downloads can cause timeout issues and odd Errno::EINVAL errors to be raised. This update provides a way to stream the contents of the response body to a file, yield a block, and maintains the original behavior if desired.