### PR TITLE
ensure single_ip is cast #to_s before comparison

### DIFF
--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -723,7 +723,7 @@ module Nexpose
       return false unless single_ip.respond_to? :from
       from = IPAddr.new(@from)
       to = @to.nil? ? from : IPAddr.new(@to)
-      other = IPAddr.new(single_ip)
+      other = IPAddr.new(single_ip.to_s)
 
       if other < from
         false


### PR DESCRIPTION
the include? method incorrectly initializes a local variable 'other' from its called argument single_ip

## Description
Nexpose::IPRange#include? expects to be passed another Nexpose::IPRange instance for its comparison logic. It instantiates a local IPAddr object from this argument without first casting to a compatible type. This is probably incorrect behavior in some versions of core runtime.

This is a quick & dirty hack that doesn't affect any of the class internal representation, local initialization or comparison logic.

## Motivation and Context
[IPRange include? function error #240](https://github.com/rapid7/nexpose-client/issues/240)

## How Has This Been Tested?
    12:28 $ bundle exec rspec
    ..................................................
    Finished in 0.35073 seconds (files took 0.48575 seconds to load)
    50 examples, 0 failures

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

