### PR TITLE
allow user to supply a cerificate file for trusted SSL

### DIFF
--- a/lib/nexpose/ajax.rb
+++ b/lib/nexpose/ajax.rb
@@ -135,7 +135,11 @@ module Nexpose
       http = Net::HTTP.new(nsc.host, nsc.port)
       http.read_timeout = timeout if timeout
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if nsc.trust_store.nil?
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      else
+        http.cert_store = nsc.trust_store
+      end
       http
     end
 

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -17,11 +17,14 @@ module Nexpose
     attr_reader :raw_response
     attr_reader :raw_response_data
 
-    def initialize(req, url, api_version = '1.1')
+    attr_reader :trust_store
+
+    def initialize(req, url, trust_store, api_version = '1.1')
       @url = url
       @req = req
       @api_version = api_version
       @url = @url.sub('API_VERSION', @api_version)
+      @trust_store = trust_store
       prepare_http_client
     end
 
@@ -34,7 +37,11 @@ module Nexpose
       #      a confirmation when the nexpose host is not localhost. In a perfect world, we would present
       #      the server signature before accepting it, but this requires either a direct callback inside
       #      of this module back to whatever UI, or opens a race condition between accept and attempt.
-      @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if @trust_store.nil?
+        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      else
+        @http.cert_store = @trust_store
+      end
       @headers = {'Content-Type' => 'text/xml'}
       @success = false
     end
@@ -93,7 +100,7 @@ module Nexpose
         # drops our HTTP connection before processing. We try 5 times to establish a
         # connection in these situations. The actual exception occurs in the Ruby
         # http library, which is why we use such generic error classes.
-      rescue OpenSSL::SSL::SSLError
+      rescue OpenSSL::SSL::SSLError => e
         if @conn_tries < 5
           @conn_tries += 1
           retry
@@ -133,8 +140,8 @@ module Nexpose
       @res.root.attributes(*args)
     end
 
-    def self.execute(url, req, api_version='1.1', options = {})
-      obj = self.new(req.to_s, url, api_version)
+    def self.execute(url, req, trust_store, api_version='1.1', options = {})
+      obj = self.new(req.to_s, url, trust_store, api_version)
       obj.execute(options)
       raise APIError.new(obj, "Action failed: #{obj.error}") unless obj.success
       obj

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -140,7 +140,7 @@ module Nexpose
       @res.root.attributes(*args)
     end
 
-    def self.execute(url, req, trust_store, api_version='1.1', options = {})
+    def self.execute(url, req, trust_store, api_version = '1.1', options = {})
       obj = self.new(req.to_s, url, trust_store, api_version)
       obj.execute(options)
       raise APIError.new(obj, "Action failed: #{obj.error}") unless obj.success

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -19,7 +19,7 @@ module Nexpose
 
     attr_reader :trust_store
 
-    def initialize(req, url, trust_store, api_version = '1.1')
+    def initialize(req, url, api_version = '1.1', trust_store = nil)
       @url = url
       @req = req
       @api_version = api_version
@@ -140,8 +140,8 @@ module Nexpose
       @res.root.attributes(*args)
     end
 
-    def self.execute(url, req, trust_store, api_version = '1.1', options = {})
-      obj = self.new(req.to_s, url, trust_store, api_version)
+    def self.execute(url, req, api_version = '1.1', options = {}, trust_store = nil)
+      obj = self.new(req.to_s, url, api_version, trust_store)
       obj.execute(options)
       raise APIError.new(obj, "Action failed: #{obj.error}") unless obj.success
       obj

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -48,9 +48,9 @@ module Nexpose
     attr_reader :trust_store
 
     # A constructor to load a Connection object from a URI
-    def self.from_uri(uri, user, pass, silo_id = nil, token = nil)
+    def self.from_uri(uri, user, pass, silo_id = nil, token = nil, trust_cert = nil)
       uri = URI.parse(uri)
-      new(uri.host, user, pass, uri.port, silo_id, token, nil)
+      new(uri.host, user, pass, uri.port, silo_id, token, trust_cert)
     end
 
     # A constructor for Connection

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -94,7 +94,7 @@ module Nexpose
     def execute(xml, version = '1.1', options = {})
       @request_xml = xml.to_s
       @api_version = version
-      response = APIRequest.execute(@url, @request_xml, @trust_store, @api_version, options)
+      response = APIRequest.execute(@url, @request_xml, @api_version, options, @trust_store)
       @response_xml = response.raw_response_data
       response
     end

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -8,6 +8,19 @@ module Nexpose
   #   # Create a new Nexpose::Connection from a URI or "URI" String
   #   nsc = Connection.from_uri('https://10.1.40.10:3780', 'nxadmin', 'password')
   #
+  #   # Create a new Nexpose::Connection with a specific port
+  #   nsc = Connection.new('10.1.40.10', 'nxadmin', 'password', 443)
+  #
+  #   # Create a new Nexpose::Connection with a silo identifier
+  #   nsc = Connection.new('10.1.40.10', 'nxadmin', 'password', 3780, 'default')
+  #
+  #   # Create a new Nexpose::Connection with a two-factor authentication (2FA) token
+  #   nsc = Connection.new('10.1.40.10', 'nxadmin', 'password', 3780, nil, '123456')
+  #
+  #   # Create a new Nexpose::Connection with an excplicitly trusted web certificate
+  #   trusted_cert = ::File.read('cert.pem')
+  #   nsc = Connection.new('10.1.40.10', 'nxadmin', 'password', 3780, nil, nil, trusted_cert)
+  #
   #   # Login to NSC and Establish a Session ID
   #   nsc.login
   #
@@ -54,6 +67,14 @@ module Nexpose
     end
 
     # A constructor for Connection
+    #
+    # @param [String] ip The IP address or hostname/FQDN of the Nexpose console.
+    # @param [String] user The username for Nexpose sessions.
+    # @param [String] pass The password for Nexpose sessions.
+    # @param [Fixnum] port The port number of the Nexpose console.
+    # @param [String] silo_id The silo identifier for Nexpose sessions.
+    # @param [String] token The two-factor authentication (2FA) token for Nexpose sessions.
+    # @param [String] trust_cert The PEM-formatted web certificate of the Nexpose console. Used for SSL validation.
     def initialize(ip, user, pass, port = 3780, silo_id = nil, token = nil, trust_cert = nil)
       @host = ip
       @port = port

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -44,9 +44,6 @@ module Nexpose
     # The last XML response received by this object, useful for debugging.
     attr_reader :response_xml
 
-    # Enforcement of certificate validation to a CA
-    attr_reader :allow_untrusted
-
     # The trust store to validate connections against if any
     attr_reader :trust_store
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -66,7 +66,7 @@ describe Site do
 
   # Monkey patch API behavior to give static responses.
   class Nexpose::APIRequest
-    def self.execute(url, trust_store, req, api_version='1.1')
+    def self.execute(url, _trust_store, _req, _api_version = '1.1')
       url
     end
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -66,7 +66,7 @@ describe Site do
 
   # Monkey patch API behavior to give static responses.
   class Nexpose::APIRequest
-    def self.execute(url, _trust_store, _req, _api_version = '1.1')
+    def self.execute(url, _req, _api_version = '1.1', _trust_store)
       url
     end
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -66,7 +66,7 @@ describe Site do
 
   # Monkey patch API behavior to give static responses.
   class Nexpose::APIRequest
-    def self.execute(url, req, api_version='1.1')
+    def self.execute(url, trust_store, req, api_version='1.1')
       url
     end
   end


### PR DESCRIPTION
Allow validation of a known certificate when establishing a connection to the nexpose instance.

## Description
Expand on the Connection object to support a known trusted certificate.
Current implementation allows for supply of certificate data in a trust_cert parameter on connection instantiation to be used for validation when supplied.  Currently maintain backwards compatibility by using VERIFY_NONE when no specific certificate data to trust is supplied.

Validation requirements do require the certificate supplied to conform for hostname verification in addition to the specific certificate to trust the connection in the default VERIFY_PEER validation mode.

## Motivation and Context
Allows module users to prevent MITM SSL attacks on the nexpose connection.
https://github.com/rapid7/nexpose-client/issues/246


## How Has This Been Tested?
Connected this branch to another project currently consuming the nexpose gem 5.1.0 and obtained the certificate from a test nexpose instance with a self signed web certificate generated with a matching CN hostname value.

Tests:
Tested with PEM format self signed certificate with valid CN for host
* Established connection (Login)
* Listed sites
* Listed Assets in a site
* Teardown of connection (Logout)

## Types of changes
- New feature (non-breaking change which adds functionality)
Currently backward compatible (happy to consider version bump and making this a breaking change)


## Checklist:
- [x] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

