### PR TITLE
bugfix/email-toAllAuthorized - use proper variable to set toAllAuthorized for Email class

### DIFF
--- a/lib/nexpose/common.rb
+++ b/lib/nexpose/common.rb
@@ -58,7 +58,7 @@ module Nexpose
 
     def to_xml
       xml = '<Email'
-      xml << %( toAllAuthorized='#{@toAllAuthorized ? 1 : 0}')
+      xml << %( toAllAuthorized='#{@to_all_authorized ? 1 : 0}')
       xml << %( sendToOwnerAs='#{@send_to_owner_as}') if @send_to_owner_as
       xml << %( sendToAclAs='#{@send_to_acl_as}') if @send_to_acl_as
       xml << %( sendAs='#{@send_as}') if @send_as


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While leveraging the gem, identified a bug in the Email class where the assignment for toAllAuthorized uses an uninitialized variable instead of the properly defined @to_all_authorized varaible.


## Motivation and Context
Currently it is not possible to create or update a report which has the setting enabled to send to all authorized users.  With this change, this functionality will begin to work as intended.


## How Has This Been Tested?
Limited testing against a local Nexpose 6.4.7 environment.  Tested the creation of new reports with setting enabled, along with the updating of current reports.


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.