### PR TITLE
Add remove_assets_from_site method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ branches:
   only:
     - master
     - /^staging.*$/
+before_install:
+  - gem update --system

--- a/lib/nexpose/device.rb
+++ b/lib/nexpose/device.rb
@@ -145,6 +145,18 @@ module Nexpose
         data.map(&AssetScan.method(:parse_json))
       end
     end
+
+    # Remove (or delete) one or more assets from a site.
+    # With asset linking enabled, this will remove the association
+    # of an asset from the given site. If this is the only site
+    # of which an asset is a member, the asset will be deleted.
+    # If asset linking is disabled, the assets will be deleted.
+    #
+    # @param [Array[Fixnum]] asset_ids The asset IDs to be removed from the site.
+    # @param [Fixnum] site_id The site ID to remove the assets from.
+    def remove_assets_from_site(asset_ids, site_id)
+      AJAX.post(self, "/data/assets/bulk-delete?siteid=#{site_id}", asset_ids, Nexpose::AJAX::CONTENT_TYPE::JSON)
+    end
   end
 
   # Object that represents a single device in a Nexpose security console.

--- a/nexpose.gemspec
+++ b/nexpose.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.4.6')
   s.add_development_dependency('simplecov', '~> 0.9.1')
+  s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('rubocop')
   s.add_development_dependency('webmock', '~> 1.20.4')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a new method to the Connection class to remove site association from a collection of assets. Note that this can result in assets being deleted if they either only belong to 1 site or if asset linking is disabled.

Usage:
```ruby
nsc = Nexpose::Connection.new('localhost', 'myuser', 'mypassword')
# login, list sites and assets, etc.

assets = [25, 72] # array of asset ID(s) is required
site_id = 3
nsc.remove_assets_from_site(assets, site_id)

```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #228

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a console with asset linking enabled where a collection of assets are associated to 2 sites.

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
