### PR TITLE
set blackout enabled

### DIFF
--- a/lib/nexpose/blackout.rb
+++ b/lib/nexpose/blackout.rb
@@ -33,7 +33,7 @@ module Nexpose
         interval = repeat_blackout_hash[:interval]
       end
 
-      new(hash[:start_date], hash[:blackout_duration], type, interval)
+      new(hash[:start_date], hash[:enabled], hash[:blackout_duration],  type, interval)
     end
 
     def to_h

--- a/lib/nexpose/blackout.rb
+++ b/lib/nexpose/blackout.rb
@@ -33,7 +33,7 @@ module Nexpose
         interval = repeat_blackout_hash[:interval]
       end
 
-      new(hash[:start_date], hash[:enabled], hash[:blackout_duration],  type, interval)
+      new(hash[:start_date], hash[:enabled], hash[:blackout_duration], type, interval)
     end
 
     def to_h


### PR DESCRIPTION
Blackout enabled was not being set when read back. The enabled field always defaults to true when not set so enabled was always true.
Related issue:
https://github.com/rapid7/nexpose-client/issues/264