### PR TITLE
adding support for listing vuln exceptions on asset groups

### DIFF
--- a/lib/nexpose/version.rb
+++ b/lib/nexpose/version.rb
@@ -1,4 +1,4 @@
 module Nexpose
   # The latest version of the Nexpose gem
-  VERSION = '5.3.3'
+  VERSION = '6.0.0'
 end


### PR DESCRIPTION
With the latest release of Nexpose, version 6.4.29 on 03/29/2017, we rolled out the ability to add vulnerability exceptions to asset groups. This patch allows for the listing of vuln exceptions that have been applied to the asset group scope.

Furthermore this patch alters the previous functionality of the `list_vuln_exceptions` method, and only returns "active" vulnerabilities. "Active" vulnerabilities are defined as vulnerabilities that allow for action to be taken upon them e.g. 'Approved', 'Under Review', 'Rejected'. 

'Deleted' vuln exceptions will no longer be output from this method, and are not subsequently unretrievable from the gem API.

Additionally this patch introduces the following attributes on the `VulnException` class: `review_date`, `submit_date`, and `asset_group_id`.

## How Has This Been Tested?
Internal Testing

