### PR TITLE
Fixed bug causing IPRange::include? always return false

### DIFF
--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -720,7 +720,6 @@ module Nexpose
     end
 
     def include?(single_ip)
-      return false unless single_ip.respond_to? :from
       from = IPAddr.new(@from)
       to = @to.nil? ? from : IPAddr.new(@to)
       other = IPAddr.new(single_ip)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deleted a statement in IPRange::include? method.

## Motivation and Context
The class IPRange, defined in `lib/nexpose/site.rb` has the instance method `include?(single_ip)`, which should check if the given ip address is included in the IPRange instance.
The following is the first statement of that method, where `:from` is the attribute containing the start of range:
`return false unless single_ip.respond_to? :from`

`single_ip` should always be a String object, so the statement will always return false since String does not have any method/attributes called `:from`.

## How Has This Been Tested?
This change has been successfully tested on an enterprise environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)