### PR TITLE
Added scan name to calls returning CompletedScan

### DIFF
--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -769,6 +769,8 @@ module Nexpose
     attr_reader :type
     # Name of the engine where the scan was run. Not the unique ID.
     attr_reader :engine_name
+    # Name of the scan that was assigned.
+    attr_reader :scan_name
 
     # Internal constructor to be called by #parse_json.
     def initialize(&block)
@@ -790,6 +792,7 @@ module Nexpose
         @risk_score = json['riskScore']
         @type = json['startedByCD'] == 'S' ? :scheduled : :manual
         @engine_name = json['scanEngineName']
+        @scan_name = json['scanName']
       end
     end
 
@@ -822,6 +825,7 @@ module Nexpose
         @risk_score = json['riskScore']
         @type = json['Scan Type'] == 'Manual' ? :manual : :scheduled
         @engine_name = json['Scan Engine']
+        @scan_name = json['Scan Name']
       end
     end
 


### PR DESCRIPTION
## Description
Added an attribute to the CompletedScan class to return scan_name.  Updated the parse methods for dyntable and json to pull out the scan name found in the results.


## Motivation and Context
With the recent change in Nexpose to assign scan names and sub site schedules, having the ability to filter and lookup scans based on names could prove beneficial.


## How Has This Been Tested?
I cloned the current master branch, updated the scan.rb file, built a new gem and ran a test script.  The change was rather small to add the attribute to a file.


## Screenshots (if appropriate):
N/A


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
