### PR TITLE
Updated username/user_name being empty on creating shared credentials

### DIFF
--- a/lib/nexpose/shared_credential.rb
+++ b/lib/nexpose/shared_credential.rb
@@ -34,7 +34,9 @@ module Nexpose
     # Domain or realm.
     attr_accessor :domain
     # User name.
-    attr_accessor :username
+    attr_accessor :user_name
+    alias :username :user_name
+    alias :username= :user_name=
     # User name to use when elevating permissions (e.g., sudo).
     attr_accessor :privilege_username
     # Boolean to indicate whether this credential applies to all sites.
@@ -48,7 +50,7 @@ module Nexpose
       cred.name = json['name']
       cred.type = json['service']
       cred.domain = json['domain']
-      cred.username = json['username']
+      cred.user_name = json['username']
       cred.privilege_username = json['privilegeElevationUsername']
       cred.all_sites = json['scope'] == 'ALL_SITES_ENABLED_DEFAULT'
       cred.last_modified = Time.at(json['lastModified']['time'] / 1000)
@@ -133,7 +135,7 @@ module Nexpose
       account.add_element('Field', { 'name' => 'database' }).add_text(@database)
 
       account.add_element('Field', { 'name' => 'domain' }).add_text(@domain)
-      account.add_element('Field', { 'name' => 'username' }).add_text(@username)
+      account.add_element('Field', { 'name' => 'username' }).add_text(@user_name)
       account.add_element('Field', { 'name' => 'ntlmhash' }).add_text(@ntlm_hash) if @ntlm_hash
       account.add_element('Field', { 'name' => 'password' }).add_text(@password) if @password
       account.add_element('Field', { 'name' => 'pemkey' }).add_text(@pem_key) if @pem_key
@@ -193,7 +195,7 @@ module Nexpose
         sc_creds_svc: @service,
         sc_creds_database: @database,
         sc_creds_domain: @domain,
-        sc_creds_uname: @username,
+        sc_creds_uname: @user_name,
         sc_creds_password: @password,
         sc_creds_pemkey: @pem_key,
         sc_creds_port: port,
@@ -225,7 +227,7 @@ module Nexpose
           when 'domain'
             cred.domain = field.text
           when 'username'
-            cred.username = field.text
+            cred.user_name = field.text
           when 'password'
             cred.password = field.text
           when 'ntlmhash'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Shared Credentials are not referencing the correct variable, so during creation of a shared credential, the username field is blank.  I updated the attr_accessor and added an alias to help for backward compatibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cannot create shared credentials using the API without an empty username.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested creating new shared credentials and pulling down existing shared credentials.  The alias should help those who already built scripts with the old attribute name

## Screenshots (if appropriate):
<!--- Drag-and-drop any relevant screenshots here, if applicable. -->


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

May need another set of eyes, but should not be breaking.

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
