### PR TITLE
Adding Ability to Set Connection Timeout Values

### DIFF
--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -116,7 +116,7 @@ module Nexpose
           # If an explicit timeout is set, don't retry.
           retry unless options.key? :timeout
         end
-        @error = "Nexpose did not respond within #{@http.read_timeout} seconds."
+        @error = "Nexpose did not respond within #{@http.read_timeout} seconds after #{@conn_tries} attempts."
       rescue ::Errno::EHOSTUNREACH, ::Errno::ENETDOWN, ::Errno::ENETUNREACH, ::Errno::ENETRESET, ::Errno::EHOSTDOWN, ::Errno::EACCES, ::Errno::EINVAL, ::Errno::EADDRNOTAVAIL
         @error = 'Nexpose host is unreachable.'
         # Handle console-level interrupts

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -51,8 +51,8 @@ module Nexpose
       @conn_tries = 0
       begin
         prepare_http_client
-        @http.read_timeout = options[:timeout] if options.key? :timeout
-        @http.open_timeout = options.key?(:open_timeout) ? options[:open_timeout] : 60
+        @http.read_timeout = options.key?(:timeout) ? options[:timeout] : 120
+        @http.open_timeout = options.key?(:open_timeout) ? options[:open_timeout] : 120
         @raw_response = @http.post(@uri.path, @req, @headers)
         @raw_response_data = @raw_response.read_body
 
@@ -111,8 +111,7 @@ module Nexpose
           @conn_tries += 1
           retry
         end
-      rescue ::Timeout::Error
-        $stdout.puts @http.read_timeout
+      rescue ::Timeout::Error => error
         if @conn_tries < 5
           @conn_tries += 1
           if options.key?(:timeout)

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -42,13 +42,12 @@ module Nexpose
       else
         @http.cert_store = @trust_store
       end
-      @headers = {'Content-Type' => 'text/xml'}
+      @headers = { 'Content-Type' => 'text/xml' }
       @success = false
     end
 
     def execute(options = {})
       @conn_tries = 0
-
       begin
         prepare_http_client
         @http.read_timeout = options[:timeout] if options.key? :timeout
@@ -62,7 +61,7 @@ module Nexpose
             @success = true
           else
             @success = false
-            @error = "User requested raw XML response. Not parsing failures."
+            @error = 'User requested raw XML response. Not parsing failures.'
           end
         else
           @res = parse_xml(@raw_response_data)
@@ -74,19 +73,19 @@ module Nexpose
 
           @sid = attributes['session-id']
 
-          if (attributes['success'] and attributes['success'].to_i == 1)
+          if (attributes['success'] && attributes['success'].to_i == 1)
             @success = true
-          elsif @api_version =~ /1.2/ and @res and (@res.get_elements '//Exception').count < 1
+          elsif @api_version =~ /1.2/ && @res && (@res.get_elements '//Exception').count < 1
             @success = true
           else
             @success = false
             if @api_version =~ /1.2/
               @res.elements.each('//Exception/Message') do |message|
-              @error = message.text.sub(/.*Exception: */, '')
+                @error = message.text.sub(/.*Exception: */, '')
               end
-            @res.elements.each('//Exception/Stacktrace') do |stacktrace|
-              @trace = stacktrace.text
-            end
+              @res.elements.each('//Exception/Stacktrace') do |stacktrace|
+                @trace = stacktrace.text
+              end
             else
               @res.elements.each('//message') do |message|
                 @error = message.text.sub(/.*Exception: */, '')
@@ -97,16 +96,16 @@ module Nexpose
             end
           end
         end
-        # This is a hack to handle corner cases where a heavily loaded Nexpose instance
-        # drops our HTTP connection before processing. We try 5 times to establish a
-        # connection in these situations. The actual exception occurs in the Ruby
-        # http library, which is why we use such generic error classes.
-      rescue OpenSSL::SSL::SSLError => e
+      # This is a hack to handle corner cases where a heavily loaded Nexpose instance
+      # drops our HTTP connection before processing. We try 5 times to establish a
+      # connection in these situations. The actual exception occurs in the Ruby
+      # http library, which is why we use such generic error classes.
+      rescue OpenSSL::SSL::SSLError
         if @conn_tries < 5
           @conn_tries += 1
           retry
         end
-      rescue ::ArgumentError, ::NoMethodError => e
+      rescue ::ArgumentError, ::NoMethodError
         if @conn_tries < 5
           @conn_tries += 1
           retry
@@ -129,7 +128,7 @@ module Nexpose
         @error = "Error parsing response: #{exc.message}"
       end
 
-      if !(@success or @error)
+      if !(@success || @error)
         @error = "Nexpose service returned an unrecognized response: #{@raw_response_data.inspect}"
       end
 
@@ -137,7 +136,7 @@ module Nexpose
     end
 
     def attributes(*args)
-      return if not @res.root
+      return unless @res.root
       @res.root.attributes(*args)
     end
 

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -115,8 +115,8 @@ module Nexpose
 
     # Execute an API request
     def execute(xml, version = '1.1', options = {})
-      options.store(:timeout, timeout) unless options.key?(:timeout)
-      options.store(:open_timeout, open_timeout)
+      options.store(:timeout, @timeout) unless options.key?(:timeout)
+      options.store(:open_timeout, @open_timeout)
       @request_xml = xml.to_s
       @api_version = version
       response = APIRequest.execute(@url, @request_xml, @api_version, options, @trust_store)

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -59,11 +59,11 @@ module Nexpose
     attr_reader :trust_store
     # The main HTTP read_timeout value
     # For more information visit the link below:
-    # https://ruby-doc.org/stdlib-<YOUR_RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
+    # https://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
     attr_accessor :timeout
     # The optional HTTP open_timeout value
     # For more information visit the link below:
-    # https://ruby-doc.org/stdlib-<YOUR_RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
+    # http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
     attr_accessor :open_timeout
 
     # A constructor to load a Connection object from a URI

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -58,8 +58,12 @@ module Nexpose
     # The trust store to validate connections against if any
     attr_reader :trust_store
     # The main HTTP read_timeout value
+    # For more information visit the link below:
+    # https://ruby-doc.org/stdlib-<RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
     attr_accessor :timeout
     # The optional HTTP open_timeout value
+    # For more information visit the link below:
+    # https://ruby-doc.org/stdlib-<RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
     attr_accessor :open_timeout
 
     # A constructor to load a Connection object from a URI

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -87,8 +87,8 @@ module Nexpose
       @trust_store  = create_trust_store(trust_cert) unless trust_cert.nil?
       @session_id   = nil
       @url          = "https://#{@host}:#{@port}/api/API_VERSION/xml"
-      @timeout      = 60
-      @open_timeout = 60
+      @timeout      = 120
+      @open_timeout = 120
     end
 
     # Establish a new connection and Session ID

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -59,11 +59,11 @@ module Nexpose
     attr_reader :trust_store
     # The main HTTP read_timeout value
     # For more information visit the link below:
-    # https://ruby-doc.org/stdlib-<RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
+    # https://ruby-doc.org/stdlib-<YOUR_RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
     attr_accessor :timeout
     # The optional HTTP open_timeout value
     # For more information visit the link below:
-    # https://ruby-doc.org/stdlib-<RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
+    # https://ruby-doc.org/stdlib-<YOUR_RUBY_VERSION>/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
     attr_accessor :open_timeout
 
     # A constructor to load a Connection object from a URI

--- a/lib/nexpose/credential_helper.rb
+++ b/lib/nexpose/credential_helper.rb
@@ -107,7 +107,7 @@ module Nexpose
     def set_ssh_service(username = nil, password = nil, elevation_type = nil, elevation_user = nil, elevation_password = nil)
       self.user_name                     = username
       self.password                      = password
-      self.permission_elevation_type     = elevation_type || ElevationType::NONE
+      self.permission_elevation_type     = elevation_type || Credential::ElevationType::NONE
       self.permission_elevation_user     = elevation_user
       self.permission_elevation_password = elevation_password
       self.service                       = Credential::Service::SSH
@@ -118,7 +118,7 @@ module Nexpose
       self.user_name                     = username
       self.password                      = password
       self.pem_format_private_key        = pemkey
-      self.permission_elevation_type     = elevation_type || ElevationType::NONE
+      self.permission_elevation_type     = elevation_type || Credential::ElevationType::NONE
       self.permission_elevation_user     = elevation_user
       self.permission_elevation_password = elevation_password
       self.service                       = Credential::Service::SSH_KEY
@@ -131,7 +131,7 @@ module Nexpose
     end
 
     # sets the Simple Network Management Protocol v3 service.
-    def set_snmpv3_service(authentication_type = AuthenticationType::NOAUTH, username = nil, password = nil, privacy_type = PrivacyType::NOPRIV, privacy_password = nil)
+    def set_snmpv3_service(authentication_type = Credential::AuthenticationType::NOAUTH, username = nil, password = nil, privacy_type = Credential::PrivacyType::NOPRIV, privacy_password = nil)
       self.authentication_type = authentication_type
       self.user_name           = username
       self.password            = password


### PR DESCRIPTION
- Misc Whitespace/formatting clean-up.
- Adding `:timeout` and `:open_timeout` to [Nexpose::Connection](https://github.com/rapid7/nexpose-client).
  - Default for both `:timeout` and `:open_timeout` are set to 120 seconds.
  - The default values will populate down to anything that uses a http(s) timeouts.
    - Mainly applies to [APIRequest](https://github.com/rapid7/nexpose-client/blob/master/lib/nexpose/api_request.rb) and [Ajax](https://github.com/rapid7/nexpose-client/blob/master/lib/nexpose/ajax.rb)
  - Added comments with links to Ruby docs for further info about how the different http timeouts are used.
- Added logging to `$stderr` when rescuing uncommon errors, asking users to open Github issues if these errors are seen in the wild.
- Fixed Namespace errors in CredentialHelper, which were missed in #287
