### PR TITLE
Allow for Starting Scan during Blackout

### DIFF
--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -196,10 +196,12 @@ module Nexpose
     # Initiate a site scan.
     #
     # @param [Fixnum] site_id Site ID to scan.
+    # @param [Boolean] blackout_override Optional. Given suffencent permissions, force bypass blackout and start scan.
     # @return [Scan] Scan launch information.
     #
-    def scan_site(site_id)
-      xml      = make_xml('SiteScanRequest', 'site-id' => site_id)
+    def scan_site(site_id, blackout_override = false)
+      xml = make_xml('SiteScanRequest', 'site-id' => site_id)
+      xml.add_attributes({ 'force' => true }) if blackout_override
       response = execute(xml)
       Scan.parse(response.res) if response.success
     end

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -540,14 +540,16 @@ module Nexpose
     #
     # @param [Connection] connection Connection to console where scan will be launched.
     # @param [String] sync_id Optional synchronization token.
+    # @param [Boolean] blackout_override Optional. Given suffencent permissions, force bypass blackout and start scan.
     # @return [Scan] Scan launch information.
     #
-    def scan(connection, sync_id = nil)
+    def scan(connection, sync_id = nil, blackout_override = false)
       xml = REXML::Element.new('SiteScanRequest')
       xml.add_attributes({ 'session-id' => connection.session_id,
                            'site-id' => @id,
                            'sync-id' => sync_id })
 
+      xml.add_attributes({ 'force' => true }) if blackout_override
       response = connection.execute(xml, '1.1', timeout: 60)
       Scan.parse(response.res) if response.success
     end


### PR DESCRIPTION
### Adding the ability for Starting a Scan during Blackout
- Two methods to start a scan during blackout
    - `Nexpose::Site.scan` ~> `site.scan(id, sync_id, blackout_override)`
    - `Nexpose::Connection.scan_site` ~> `nsc.scan_site(id, blackout_override)`
- Set the `blackout_override` argument to `true` to override the blackout. 
    - Even if set to `true` Nexpose will still do a check on the backend to verify the user has the appropriate level of permissions to bypass the blackout.