### PR TITLE
Some methods were not honoring custom Connection Timeouts

### DIFF
--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -57,11 +57,11 @@ module Nexpose
     attr_reader :response_xml
     # The trust store to validate connections against if any
     attr_reader :trust_store
-    # The main HTTP read_timeout value
+    # The main HTTP read_timeout value, in seconds
     # For more information visit the link below:
     # https://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html#read_timeout-attribute-method
     attr_accessor :timeout
-    # The optional HTTP open_timeout value
+    # The optional HTTP open_timeout value, in seconds
     # For more information visit the link below:
     # http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout-attribute-method
     attr_accessor :open_timeout

--- a/lib/nexpose/group.rb
+++ b/lib/nexpose/group.rb
@@ -159,7 +159,7 @@ module Nexpose
     #
     def self.load(connection, id)
       xml = %(<AssetGroupConfigRequest session-id="#{connection.session_id}" group-id="#{id}"/>)
-      r   = APIRequest.execute(connection.url, xml)
+      r   = APIRequest.execute(connection.url, xml, '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout })
       parse(r.res)
     end
 

--- a/lib/nexpose/role.rb
+++ b/lib/nexpose/role.rb
@@ -157,7 +157,7 @@ module Nexpose
     def self.load(nsc, name, scope = Scope::SILO)
       xml = nsc.make_xml('RoleDetailsRequest')
       xml.add_element('Role', { 'name' => name, 'scope' => scope })
-      response = APIRequest.execute(nsc.url, xml, '1.2')
+      response = APIRequest.execute(nsc.url, xml, '1.2', { timeout: nsc.timeout, open_timeout: nsc.open_timeout })
 
       if response.success
         elem = REXML::XPath.first(response.res, 'RoleDetailsResponse/Role/')
@@ -179,7 +179,7 @@ module Nexpose
       end
       xml.add_element(as_xml)
 
-      response  = APIRequest.execute(nsc.url, xml, '1.2')
+      response  = APIRequest.execute(nsc.url, xml, '1.2', { timeout: nsc.timeout, open_timeout: nsc.open_timeout })
       xml       = REXML::XPath.first(response.res, 'RoleCreateResponse')
       @id       = xml.attributes['id'].to_i unless @existing
       @existing = true

--- a/lib/nexpose/site.rb
+++ b/lib/nexpose/site.rb
@@ -550,7 +550,7 @@ module Nexpose
                            'sync-id' => sync_id })
 
       xml.add_attributes({ 'force' => true }) if blackout_override
-      response = connection.execute(xml, '1.1', timeout: 60)
+      response = connection.execute(xml, '1.1', timeout: connection.timeout)
       Scan.parse(response.res) if response.success
     end
   end


### PR DESCRIPTION
There were four methods that had non-standard direct calls to `APIRequest.execute` causing the custom set timeouts to be ignored. 

The following methods have been updated to use the [`Connection::timeout`](https://github.com/rapid7/nexpose-client/wiki/Using-Connection-HTTP-timeouts): 
- [`AssetGroup.load`](https://github.com/rapid7/nexpose-client/blob/9ee7203623e77cceca2d62f35239a41517d5bea9/lib/nexpose/group.rb#L152-L164)
- [`Role.load`](https://github.com/rapid7/nexpose-client/blob/9ee7203623e77cceca2d62f35239a41517d5bea9/lib/nexpose/role.rb#L149-L168)
- [`Role::save`](https://github.com/rapid7/nexpose-client/blob/9ee7203623e77cceca2d62f35239a41517d5bea9/lib/nexpose/role.rb#L170-L187)
- [`Site::scan`](https://github.com/rapid7/nexpose-client/blob/9ee7203623e77cceca2d62f35239a41517d5bea9/lib/nexpose/site.rb#L539-L556)


