### PR TITLE
Updated for Ruby 2.4 Support

### DIFF
--- a/lib/nexpose/rexlite/mime/header.rb
+++ b/lib/nexpose/rexlite/mime/header.rb
@@ -36,7 +36,7 @@ module Rexlite
       end
 
       def find(idx)
-        if (idx.class == ::Fixnum)
+        if idx.kind_of?(Integer)
           return self.headers[idx]
         else
           self.headers.each do |pair|
@@ -59,7 +59,7 @@ module Rexlite
       end
 
       def remove(idx)
-        if (idx.class == ::Fixnum)
+        if idx.kind_of?(Integer)
           self.headers.delete_at(idx)
         else
           self.headers.each_index do |i|


### PR DESCRIPTION
## Description
::Fixnum is deprecated in Ruby 2.4. Updated with kind_of?(Integer).

## Motivation and Context
Just a minor update to stop warnings for deprecated features.

## How Has This Been Tested?
Ported the changes from the rapid7/rex-mime project.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)