### PR TITLE
Add a method to add common vuln status filters to report configs

### DIFF
--- a/lib/nexpose/report.rb
+++ b/lib/nexpose/report.rb
@@ -207,10 +207,10 @@ module Nexpose
       filters << Filter.new(type, id)
     end
 
-    # Add the common vulnerability status filters as used by the UI for most
-    #  report templates (defaults). Recommended for reports that do not require
-    # 'not vlunerable' results to be included. The following statuses are added:
-    # vulnerable-exploted, vulnerable-version, and potential.
+    # Add the common vulnerability status filters as used by the UI for export
+    # and jasper report templates (the default filters). Recommended for reports
+    # that do not require 'not vulnerable' results to be included. The following
+    # statuses are added: vulnerable-exploted, vulnerable-version, and potential.
     def add_common_vuln_status_filters
       ['vulnerable-exploited', 'vulnerable-version', 'potential'].each do |vuln_status|
         filters << Filter.new('vuln-status', vuln_status)

--- a/lib/nexpose/report.rb
+++ b/lib/nexpose/report.rb
@@ -207,6 +207,16 @@ module Nexpose
       filters << Filter.new(type, id)
     end
 
+    # Add the common vulnerability status filters as used by the UI for most
+    #  report templates (defaults). Recommended for reports that do not require
+    # 'not vlunerable' results to be included. The following statuses are added:
+    # vulnerable-exploted, vulnerable-version, and potential.
+    def add_common_vuln_status_filters
+      ['vulnerable-exploited', 'vulnerable-version', 'potential'].each do |vuln_status|
+        filters << Filter.new('vuln-status', vuln_status)
+      end
+    end
+
     def to_xml
       xml = %(<AdhocReportConfig format="#{@format}" template-id="#{@template_id}")
       xml << %( owner="#{@owner}") if @owner


### PR DESCRIPTION
## Description
This is a convenience method for creating reports that should behave the same as reports created in the web UI.

## Motivation and Context
It's annoying to remember to do this when creating reports from scratch.

## How Has This Been Tested?
Not tested

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
