### PR TITLE
When passed a filename, download a report in chunks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.1.9
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.1.10
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - jruby-9.0.5.0
 jdk:
   - oraclejdk8

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -143,11 +143,15 @@ module Nexpose
         http.cert_store = @trust_store
       end
       headers = { 'Cookie' => "nexposeCCSessionID=#{@session_id}" }
-      resp    = http.get(uri.to_s, headers)
 
       if file_name
-        ::File.open(file_name, 'wb') { |file| file.write(resp.body) }
+        http.request_get(uri.to_s, headers) do |resp|
+          ::File.open(file_name, 'wb') do |file|
+            resp.read_body { |chunk| file.write(chunk) }
+          end
+        end
       else
+        resp = http.get(uri.to_s, headers)
         resp.body
       end
     end

--- a/spec/fixtures/cassettes/download_report.yml
+++ b/spec/fixtures/cassettes/download_report.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://nexpose.local:3780/api/1.1/xml
+    body:
+      encoding: UTF-8
+      string: "<LoginRequest password='johndoe' sync-id='0' user-id='johndoe'></LoginRequest>"
+    headers:
+      Content-Type:
+      - text/xml
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Set-Cookie:
+      - JSESSIONID=6D064F67374C1663E32D088987E90ED5; Path=/; Secure; HttpOnly
+      Date:
+      - Fri, 27 Mar 2015 19:44:40 GMT
+      Server:
+      - NSC/0.6.4 (JVM)
+      Cache-Control:
+      - no-cache; max-age=0
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <LoginResponse success="1" session-id="8CD4D7B7E0A7FABFA85C45D37AC952640CE471B3"/>
+    http_version:
+  recorded_at: Fri, 27 Mar 2015 19:44:40 GMT
+- request:
+    method: get
+    uri: https://nexpose.local:3780/reports/00000001/00000002/report.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Cookie:
+      - nexposeCCSessionID=XXX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-store, must-revalidate
+      Content-Disposition:
+      - filename=report.xml
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Thu, 25 Aug 2016 15:37:38 GMT
+      Server:
+      - Security Console
+    body:
+      encoding: ASCII-8BIT
+      string: "<NexposeReport version=\"2.0\"></NexposeReport>"
+    http_version:
+  recorded_at: Thu, 25 Aug 2016 15:37:39 GMT

--- a/spec/nexpose/connection/download_spec.rb
+++ b/spec/nexpose/connection/download_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe Nexpose::Connection, :with_api_login do
+  describe '#download' do
+    let(:report_url) { 'https://nexpose.local:3780/reports/00000001/00000002/report.xml' }
+
+    it 'downloads report to string' do
+      report = VCR.use_cassette('download_report') do
+        connection.download(report_url)
+      end
+
+      expect(report).to eq('<NexposeReport version="2.0"></NexposeReport>')
+    end
+
+    it 'downloads report with file name' do
+      tf = Tempfile.new
+      path = tf.path
+      tf.close
+      tf.unlink
+
+      begin
+        VCR.use_cassette('download_report') do
+          connection.download(report_url, path)
+        end
+
+        expect(File.read(path)).to eq('<NexposeReport version="2.0"></NexposeReport>')
+      ensure
+        File.delete(path) if File.exist?(path)
+      end
+    end
+
+    it 'downloads report with file object' do
+      tf = Tempfile.new
+
+      begin
+        VCR.use_cassette('download_report') do
+          connection.download(report_url, tf)
+        end
+
+        expect(tf.read).to eq('<NexposeReport version="2.0"></NexposeReport>')
+      ensure
+        tf.close
+        tf.unlink
+      end
+    end
+  end
+end

--- a/spec/nexpose/connection/download_spec.rb
+++ b/spec/nexpose/connection/download_spec.rb
@@ -14,7 +14,7 @@ describe Nexpose::Connection, :with_api_login do
     end
 
     it 'downloads report with file name' do
-      tf = Tempfile.new
+      tf = Tempfile.new('download_spec')
       path = tf.path
       tf.close
       tf.unlink
@@ -31,7 +31,7 @@ describe Nexpose::Connection, :with_api_login do
     end
 
     it 'downloads report with file object' do
-      tf = Tempfile.new
+      tf = Tempfile.new('download_spec')
 
       begin
         VCR.use_cassette('download_report') do


### PR DESCRIPTION
## Description

Rather than pulling an entire 6-8 GB report into a string in memory to
immediately write it out to a file, use the built-in feature of Net::HTTP to
retrieve the result in chunks and write them out as they are read from the
remote host. This prevents receiving `NoMemoryError` issues when downloading
huge reports.

While here, also add Travis CI testing for Ruby 2.5.

## Motivation and Context

We're hitting out of memory errors trying to download huge reports using this gem.

## How Has This Been Tested?

We have a set of VCR-based tests that invoke this gem, and specifically the `download` method. I was able to use this version of the `download` method and see our test suite pass successfully.

~Unfortunately, we don't have tests for this method in this gem itself. It probably makes sense to do some sort of VCR recording or cassette, which I could attempt if you think that makes sense.~ EDIT: tests now included.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have updated the documentation accordingly (if changes are required).
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
