### PR TITLE
Allow setting of invulnerable storage

### DIFF
--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -162,6 +162,19 @@ module Nexpose
       gen.attributes['disableWebSpider'] = enable ? '0' : '1'
     end
 
+    # @return [Boolean] Whether StoreInvulnerableResults in enabled.
+    def invulnerable_storage?
+      gen = REXML::XPath.first(@xml, 'ScanTemplate/General')
+      gen.attributes['invulnerableStorage'] == 'on'
+    end
+
+    # Adjust whether to Store Invulnerable Results with this template.
+    # @param [Boolean] enable Whether to StoreInvulnerableResults.
+    def invulnerable_storage=(enable)
+      gen = REXML::XPath.first(@xml, 'ScanTemplate/General')
+      gen.attributes['invulnerableStorage'] = enable ? 'on' : 'off'
+    end
+
     # Adjust the number of threads to use per scan engine for this template
     # @param [Integer] threads the number of threads to use per engine
     def scan_threads=(threads)

--- a/lib/nexpose/scan_template.rb
+++ b/lib/nexpose/scan_template.rb
@@ -162,14 +162,14 @@ module Nexpose
       gen.attributes['disableWebSpider'] = enable ? '0' : '1'
     end
 
-    # @return [Boolean] Whether StoreInvulnerableResults in enabled.
+    # @return [Boolean] Whether Invulnerable Results is enabled.
     def invulnerable_storage?
       gen = REXML::XPath.first(@xml, 'ScanTemplate/General')
       gen.attributes['invulnerableStorage'] == 'on'
     end
 
-    # Adjust whether to Store Invulnerable Results with this template.
-    # @param [Boolean] enable Whether to StoreInvulnerableResults.
+    # Adjust whether to Store Invulnerable results with this template.
+    # @param [Boolean] enable Whether to Store Invulnerable results.
     def invulnerable_storage=(enable)
       gen = REXML::XPath.first(@xml, 'ScanTemplate/General')
       gen.attributes['invulnerableStorage'] = enable ? 'on' : 'off'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows reading and setting the InvulnerableStorage scan template option


## Motivation and Context
The InvulnerableStorage option is being changed to default off in Nexpose. Controlling this value is important for certain workflows.


## How Has This Been Tested?
Imported this version of nexpose-client to Nexpose, enabled InvulnerableStorage, ran tests to show invulnerable results were being stored and reported


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)
