### PR TITLE
Sup 1233 nexpose custom sni host

### DIFF
--- a/lib/nexpose/ajax.rb
+++ b/lib/nexpose/ajax.rb
@@ -137,6 +137,7 @@ module Nexpose
       http.read_timeout = (timeout || nsc.timeout)
       http.open_timeout = nsc.open_timeout
       http.use_ssl = true
+      http.ipaddr = nsc.connect_host
       if nsc.trust_store.nil?
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       else

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module Nexpose
   class APIRequest
     include XMLUtils
@@ -26,6 +28,7 @@ module Nexpose
       @api_version = api_version
       @url = @url.sub('API_VERSION', @api_version)
       @trust_store = trust_store
+      @connect_host = connect_host
       prepare_http_client
     end
 

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Nexpose
   class APIRequest
     include XMLUtils

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -4,6 +4,7 @@ module Nexpose
 
     attr_reader :http
     attr_reader :uri
+    attr_reader :connect_host
     attr_reader :headers
 
     attr_reader :req
@@ -19,7 +20,7 @@ module Nexpose
 
     attr_reader :trust_store
 
-    def initialize(req, url, api_version = '1.1', trust_store = nil)
+    def initialize(req, url, api_version = '1.1', trust_store = nil, connect_host = nil)
       @url = url
       @req = req
       @api_version = api_version
@@ -32,6 +33,7 @@ module Nexpose
       @uri = URI.parse(@url)
       @http = Net::HTTP.new(@uri.host, @uri.port)
       @http.use_ssl = true
+      @http.ipaddr = @connect_host
       #
       # XXX: This is obviously a security issue, however, we handle this at the client level by forcing
       #      a confirmation when the nexpose host is not localhost. In a perfect world, we would present

--- a/lib/nexpose/api_request.rb
+++ b/lib/nexpose/api_request.rb
@@ -144,8 +144,8 @@ module Nexpose
       @res.root.attributes(*args)
     end
 
-    def self.execute(url, req, api_version = '1.1', options = {}, trust_store = nil)
-      obj = self.new(req.to_s, url, api_version, trust_store)
+    def self.execute(url, req, api_version = '1.1', options = {}, trust_store = nil, connect_host = nil)
+      obj = self.new(req.to_s, url, api_version, trust_store, connect_host)
       obj.execute(options)
       raise APIError.new(obj, "Action failed: #{obj.error}") unless obj.success
       obj

--- a/lib/nexpose/connection.rb
+++ b/lib/nexpose/connection.rb
@@ -41,6 +41,8 @@ module Nexpose
     attr_reader :session_id
     # The hostname or IP Address of the NSC
     attr_reader :host
+    # Host or IP address to connect through for tunneled connections. Allows sending correct host for SNI
+    attr_reader :connect_host
     # The port of the NSC (default is 3780)
     attr_reader :port
     # The username used to login to the NSC
@@ -81,8 +83,9 @@ module Nexpose
     # @param [String] silo_id The silo identifier for Nexpose sessions.
     # @param [String] token The two-factor authentication (2FA) token for Nexpose sessions.
     # @param [String] trust_cert The PEM-formatted web certificate of the Nexpose console. Used for SSL validation.
-    def initialize(ip, user, pass, port = 3780, silo_id = nil, token = nil, trust_cert = nil)
+    def initialize(ip, user, pass, port = 3780, silo_id = nil, token = nil, trust_cert = nil, connect_host = nil)
       @host         = ip
+      @connect_host = connect_host
       @username     = user
       @password     = pass
       @port         = port
@@ -121,7 +124,7 @@ module Nexpose
       options.store(:open_timeout, @open_timeout)
       @request_xml = xml.to_s
       @api_version = version
-      response = APIRequest.execute(@url, @request_xml, @api_version, options, @trust_store)
+      response = APIRequest.execute(@url, @request_xml, @api_version, options, @trust_store, @connect_host)
       @response_xml = response.raw_response_data
       response
     end

--- a/lib/nexpose/group.rb
+++ b/lib/nexpose/group.rb
@@ -159,7 +159,7 @@ module Nexpose
     #
     def self.load(connection, id)
       xml = %(<AssetGroupConfigRequest session-id="#{connection.session_id}" group-id="#{id}"/>)
-      r   = APIRequest.execute(connection.url, xml, '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout })
+      r   = APIRequest.execute(connection.url, xml, '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, connection.connect_host)
       parse(r.res)
     end
 

--- a/spec/nexpose/ajax_spec.rb
+++ b/spec/nexpose/ajax_spec.rb
@@ -9,10 +9,12 @@ describe Nexpose::AJAX do
   let(:open_timeout) { 120 }
   let(:trust_store) { nil }
   let(:port) { 3780 }
-  let(:connection) { double('Nexpose::Connection', :host => console_hostname, :port => port, :timeout => connection_timeout, :open_timeout => open_timeout, :connect_host => connect_host, :trust_store => trust_store)
-  }
+  let(:connection) do
+    double('Nexpose::Connection', host: console_hostname, port: port, timeout: connection_timeout, open_timeout: open_timeout,
+                                  connect_host: connect_host, trust_store: trust_store)
+  end
   let(:timeout) { nil }
-  
+
   subject!(:https) { Nexpose::AJAX.https(connection, timeout) }
 
   describe '#https' do

--- a/spec/nexpose/ajax_spec.rb
+++ b/spec/nexpose/ajax_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Nexpose::AJAX do
+  let(:console_hostname) { 'on-prem.nexpose.company.int' }
+  let(:username) { 'admin' }
+  let(:password) { 'password' }
+  let(:connect_host) { nil }
+  let(:connection_timeout) { 120 }
+  let(:open_timeout) { 120 }
+  let(:trust_store) { nil }
+  let(:port) { 3780 }
+  let(:connection) { double('Nexpose::Connection', :host => console_hostname, :port => port, :timeout => connection_timeout, :open_timeout => open_timeout, :connect_host => connect_host, :trust_store => trust_store)
+  }
+  let(:timeout) { nil }
+  
+  subject!(:https) { Nexpose::AJAX.https(connection, timeout) }
+
+  describe '#https' do
+    context 'using connection defaults' do
+      it 'disables cert verification' do
+        expect(https.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+        expect(https.cert_store).to be_nil
+      end
+
+      it 'uses connection default timeout' do
+        expect(https.read_timeout).to eq(connection.timeout)
+      end
+
+      it 'sets http hostname and port from connection' do
+        expect(https.address).to eq(connection.host)
+        expect(https.port).to eq(connection.port)
+      end
+
+      it 'leaves ipaddr nil' do
+        expect(https.ipaddr).to be_nil
+      end
+    end
+
+    context 'connect_host is provided in the connection' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+      it 'sets ipaddr on the Net::HTTPS' do
+        expect(https.ipaddr).to eq(connect_host)
+      end
+    end
+
+    context 'timeout is provided in the call' do
+      let(:timeout) { 240 }
+
+      it 'sets timeout from the method call' do
+        expect(https.read_timeout).to eq(timeout)
+      end
+    end
+
+    context 'cert_store is provided in the connection' do
+      let(:trust_store) { OpenSSL::X509::Store.new }
+
+      it 'sets http cert store' do
+        expect(https.cert_store).to equal(trust_store)
+      end
+    end
+  end
+end

--- a/spec/nexpose/api_request_spec.rb
+++ b/spec/nexpose/api_request_spec.rb
@@ -10,12 +10,11 @@ describe Nexpose::APIRequest do
   let(:connection_timeout) { 120 }
   let(:open_timeout) { 120 }
   let(:trust_store) { nil }
-  let(:request_xml) { "" }
-
+  let(:request_xml) { '' }
 
   describe '#new' do
-    subject!(:api_request){ Nexpose::APIRequest.new(request_xml, url, '1,1', trust_store, connect_host) }
-  
+    subject!(:api_request) { Nexpose::APIRequest.new(request_xml, url, '1,1', trust_store, connect_host) }
+
     context 'with defaults' do
       it 'creates a Net::HTTP with no ipaddr' do
         expect(api_request.http.ipaddr).to eq(nil)
@@ -32,10 +31,10 @@ describe Nexpose::APIRequest do
   end
 
   describe 'execute' do
-    let(:options){ {:timeout => 120, :open_timeout => 120, :raw => true} }
+    let(:options) { { timeout: 120, open_timeout: 120, raw: true } }
     let(:request_object) { Nexpose::APIRequest.new(request_xml, url, '1.1', trust_store, connect_host) }
     before do
-      allow(Nexpose::APIRequest).to receive(:new).and_return( request_object )
+      allow(Nexpose::APIRequest).to receive(:new).and_return(request_object)
       allow(request_object).to receive(:execute)
       allow(request_object).to receive(:success).and_return(true)
     end

--- a/spec/nexpose/api_request_spec.rb
+++ b/spec/nexpose/api_request_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Nexpose::APIRequest do
+  let(:console_hostname) { 'on-prem.nexpose.company.int' }
+  let(:port) { 3780 }
+  let(:url) { "https://#{console_hostname}:#{port}/api/API_VERSION/xml" }
+  let(:username) { 'admin' }
+  let(:password) { 'password' }
+  let(:connect_host) { nil }
+  let(:connection_timeout) { 120 }
+  let(:open_timeout) { 120 }
+  let(:trust_store) { nil }
+  let(:request_xml) { "" }
+
+
+  describe '#new' do
+    subject!(:api_request){ Nexpose::APIRequest.new(request_xml, url, '1,1', trust_store, connect_host) }
+  
+    context 'with defaults' do
+      it 'creates a Net::HTTP with no ipaddr' do
+        expect(api_request.http.ipaddr).to eq(nil)
+      end
+    end
+
+    context 'with connect_host provided' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+      it 'creates a Net::HTTP with ipaddr parameter' do
+        expect(api_request.http.ipaddr).to eq(connect_host)
+      end
+    end
+  end
+
+  describe 'execute' do
+    let(:options){ {:timeout => 120, :open_timeout => 120, :raw => true} }
+    let(:request_object) { Nexpose::APIRequest.new(request_xml, url, '1.1', trust_store, connect_host) }
+    before do
+      allow(Nexpose::APIRequest).to receive(:new).and_return( request_object )
+      allow(request_object).to receive(:execute)
+      allow(request_object).to receive(:success).and_return(true)
+    end
+    subject!(:returned_request) { Nexpose::APIRequest.execute(url, request_xml, '1.1', options, trust_store, connect_host) }
+
+    context 'with defaults' do
+      it 'creates a Net::HTTP with no ipadidr' do
+        expect(returned_request.http.ipaddr).to eq(nil)
+      end
+      it 'executes the request' do
+        expect(request_object).to have_received(:execute)
+      end
+    end
+
+    context 'with connect_host provided' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+      it 'creates a Net::HTTP with ipaddr parameter' do
+        expect(returned_request.http.ipaddr).to eq(connect_host)
+      end
+      it 'executes the request' do
+        expect(request_object).to have_received(:execute)
+      end
+    end
+  end
+end

--- a/spec/nexpose/connection_spec.rb
+++ b/spec/nexpose/connection_spec.rb
@@ -1,15 +1,37 @@
 require 'spec_helper'
 
 describe Nexpose::Connection do
+  let(:uri) { 'https://nexpose.local:3780/' }
+  let(:username) { nil }
+  let(:password) { nil }
+  let(:silo_id) { nil }
+  let(:connect_host) { nil }
+  let(:token) { nil }
+  let(:trust_cert) { nil }
+  let(:port) { nil }
+
+  describe '#new' do
+    subject(:connection) { Nexpose::Connection.new(uri, username, password, port, silo_id, token, trust_cert, connect_host) }
+
+    context 'with default connection params' do
+      it 'has no connect_host attribute value' do
+        expect(connection.connect_host).to be_nil
+      end
+    end
+
+    context 'with connect_host provided' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+      it 'sets connect_host attribute' do
+        expect(connection.connect_host).to equal(connect_host)
+      end
+    end
+  end
+
   describe '.from_uri' do
-    let(:username) { nil }
-    let(:password) { nil }
-    let(:silo_id) { nil }
     subject(:connection) { Nexpose::Connection.from_uri(uri, username, password, silo_id) }
 
     context 'with the default port' do
-      let(:uri) { 'https://nexpose.local:3780/' }
-
       it 'initializes a new Connection' do
         expect(connection.host).to eq('nexpose.local')
         expect(connection.password).to eq(password)
@@ -26,6 +48,40 @@ describe Nexpose::Connection do
         expect(connection.password).to eq(password)
         expect(connection.port).to eq(1234)
         expect(connection.username).to eq(username)
+      end
+    end
+  end
+
+  describe '#execute' do
+    let(:connection) { Nexpose::Connection.new(uri, username, password, port, silo_id, token, trust_cert, connect_host) }
+    let(:test_xml) { "<LoginRequest password='password' sync-id='0' user-id='username'></LoginRequest>" }
+    let(:options) { {} }
+    
+    before do 
+      allow(Nexpose::APIRequest).to receive(:execute).and_return( double(raw_response_data: 'success') )
+    end
+
+    subject!(:execute_response) { connection.execute(test_xml, nil, options) }
+
+    context 'with default connection params' do
+      it 'calls APIRequest#execute without connect_host' do
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, test_xml.to_s, nil, options, trust_cert, nil)
+      end
+    end
+
+    context 'with connect_host defined' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+      it 'calls APIRequest#execute with connect_host parameter' do
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, test_xml.to_s, nil, options, trust_cert, connect_host)
+      end
+    end
+
+    context 'with only request xml provided' do
+      subject!(:execute_response) { connection.execute(test_xml) }
+
+      it 'request defaults timeouts and api version' do
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, test_xml.to_s, '1.1', {:open_timeout=>120, :timeout=>120}, trust_cert, connect_host)
       end
     end
   end

--- a/spec/nexpose/connection_spec.rb
+++ b/spec/nexpose/connection_spec.rb
@@ -56,9 +56,9 @@ describe Nexpose::Connection do
     let(:connection) { Nexpose::Connection.new(uri, username, password, port, silo_id, token, trust_cert, connect_host) }
     let(:test_xml) { "<LoginRequest password='password' sync-id='0' user-id='username'></LoginRequest>" }
     let(:options) { {} }
-    
-    before do 
-      allow(Nexpose::APIRequest).to receive(:execute).and_return( double(raw_response_data: 'success') )
+
+    before do
+      allow(Nexpose::APIRequest).to receive(:execute).and_return(double(raw_response_data: 'success'))
     end
 
     subject!(:execute_response) { connection.execute(test_xml, nil, options) }
@@ -81,8 +81,10 @@ describe Nexpose::Connection do
       subject!(:execute_response) { connection.execute(test_xml) }
 
       it 'request defaults timeouts and api version' do
-        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, test_xml.to_s, '1.1', {:open_timeout=>120, :timeout=>120}, trust_cert, connect_host)
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, test_xml.to_s, '1.1', { open_timeout: 120, timeout: 120 }, trust_cert,
+                                                                    connect_host)
       end
     end
   end
 end
+

--- a/spec/nexpose/group_spec.rb
+++ b/spec/nexpose/group_spec.rb
@@ -11,28 +11,33 @@ describe Nexpose::AssetGroup do
   let(:open_timeout) { 120 }
   let(:trust_store) { nil }
 
-  let(:connection) { double('Nexpose::Connection', :host => console_hostname, :port => port, :timeout => connection_timeout, :open_timeout => open_timeout, :url => url, :connect_host => connect_host, :trust_store => trust_store, :session_id => 'asdf')
-  }
+  let(:connection) do
+    double('Nexpose::Connection', host: console_hostname, port: port, timeout: connection_timeout, open_timeout: open_timeout, url: url,
+                                  connect_host: connect_host, trust_store: trust_store, session_id: 'asdf')
+  end
   let(:group_id) { 52 }
   before do
-    allow(Nexpose::APIRequest).to receive(:execute).and_return( double('nexpose_resonse', :res => "<AssetGroupConfigResponse><AssetGroup></AssetGroup></AssetGroupConfigResponse>") )
-    allow(Nexpose::AssetGroup).to receive(:parse).and_return( Nexpose::AssetGroup.new('test group name', 'asset group for testing', group_id, 1000.0) )
+    allow(Nexpose::APIRequest).to receive(:execute).and_return(double('nexpose_resonse',
+                                                                      res: '<AssetGroupConfigResponse><AssetGroup></AssetGroup></AssetGroupConfigResponse>'))
+    allow(Nexpose::AssetGroup).to receive(:parse).and_return(Nexpose::AssetGroup.new('test group name', 'asset group for testing', group_id, 1000.0))
   end
-  subject!{ Nexpose::AssetGroup.load(connection, group_id) }
+  subject! { Nexpose::AssetGroup.load(connection, group_id) }
 
   describe 'self.load' do
-      context 'with default connection parameters' do
-        it 'executes and APIRequest without connect_host' do
-          expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, nil)
-        end
+    context 'with default connection parameters' do
+      it 'executes and APIRequest without connect_host' do
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1',
+                                                                    { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, nil)
       end
+    end
 
-      context 'with connect_host provided in connection' do
-        let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+    context 'with connect_host provided in connection' do
+      let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
 
-        it 'executes an APIRequest with connect_host' do
-          expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, connect_host)
-        end
+      it 'executes an APIRequest with connect_host' do
+        expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1',
+                                                                    { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, connect_host)
       end
+    end
   end
 end

--- a/spec/nexpose/group_spec.rb
+++ b/spec/nexpose/group_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Nexpose::AssetGroup do
+  let(:console_hostname) { 'on-prem.nexpose.company.int' }
+  let(:port) { 3780 }
+  let(:url) { "https://#{console_hostname}:#{port}/api/API_VERSION/xml" }
+  let(:username) { 'admin' }
+  let(:password) { 'password' }
+  let(:connect_host) { nil }
+  let(:connection_timeout) { 120 }
+  let(:open_timeout) { 120 }
+  let(:trust_store) { nil }
+
+  let(:connection) { double('Nexpose::Connection', :host => console_hostname, :port => port, :timeout => connection_timeout, :open_timeout => open_timeout, :url => url, :connect_host => connect_host, :trust_store => trust_store, :session_id => 'asdf')
+  }
+  let(:group_id) { 52 }
+  before do
+    allow(Nexpose::APIRequest).to receive(:execute).and_return( double('nexpose_resonse', :res => "<AssetGroupConfigResponse><AssetGroup></AssetGroup></AssetGroupConfigResponse>") )
+    allow(Nexpose::AssetGroup).to receive(:parse).and_return( Nexpose::AssetGroup.new('test group name', 'asset group for testing', group_id, 1000.0) )
+  end
+  subject!{ Nexpose::AssetGroup.load(connection, group_id) }
+
+  describe 'self.load' do
+      context 'with default connection parameters' do
+        it 'executes and APIRequest without connect_host' do
+          expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, nil)
+        end
+      end
+
+      context 'with connect_host provided in connection' do
+        let(:connect_host) { 'virtual-tunnel.us.kennasec.com' }
+
+        it 'executes an APIRequest with connect_host' do
+          expect(Nexpose::APIRequest).to have_received(:execute).with(connection.url, %(<AssetGroupConfigRequest session-id="asdf" group-id="52"/>), '1.1', { timeout: connection.timeout, open_timeout: connection.open_timeout }, nil, connect_host)
+        end
+      end
+  end
+end


### PR DESCRIPTION
# SUP-1233

## Description
This PR modifies the Nexpose api client gem to make use of the Net::HTTP parameter `ipaddr`, which allows for a custom SNI value. To source that value, we add a new parameter `connect_host` to the relevant methods. Logic to select which value goes where lives in importer.

This only changes the methods we directly use from importer.

## Motivation and Context
A prospective client wants to use Kenna Virtual Tunnel with Nexpose.  After getting the tunnel connected we found the connector failing with SSL errors. After much troubleshooting, the only way to complete a TLS/SSL connection was to alter the SNI in the handshake to match the client's hostname rather than the virtual-tunnel hostname we directly connect to on our end. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
<!--- Drag-and-drop any relevant screenshots here, if applicable. -->


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
