### PR TITLE
remove preceding slash from url for spring 4.3.30 minor upgrade nexpose

### DIFF
--- a/lib/eso/configuration/configuration_manager.rb
+++ b/lib/eso/configuration/configuration_manager.rb
@@ -66,7 +66,7 @@ module Eso
     # return [JSON] A json object representing a configuration
     # TODO : Update to use an Eso::Configuration
     def get_configuration(configuration_id)
-      json_data = ::Nexpose::AJAX.get(@nexpose_console, "#{@url}/service/configuration/id/#{configuration_id}", ::Nexpose::AJAX::CONTENT_TYPE::JSON)
+      json_data = ::Nexpose::AJAX.get(@nexpose_console, "#{@url}service/configuration/id/#{configuration_id}", ::Nexpose::AJAX::CONTENT_TYPE::JSON)
       JSON.parse(json_data, :symbolize_names => true)
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Spring Minor upgrade in nexpose has caused this to fail our cucumber tests.
preceding "/" is not allowed and spring has enforced stricter rules.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken cucumber tests for GET requests using this URL.
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
<!--- Drag-and-drop any relevant screenshots here, if applicable. -->


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
