### PR TITLE
NEX-56926: remove .xml extension on dyntable endpoints used by cucumbers

### DIFF
--- a/lib/nexpose/data_table.rb
+++ b/lib/nexpose/data_table.rb
@@ -65,7 +65,7 @@ module Nexpose
     # @return [Array[Hash]] array of hashes representing the requested table.
     #
     # Example usage:
-    #   DataTable._get_dyn_table(@console, '/data/asset/os/dyntable.xml?tableID=OSSynopsisTable')
+    #   DataTable._get_dyn_table(@console, '/data/asset/os/dyntable?tableID=OSSynopsisTable')
     #
     def _get_dyn_table(console, address, payload = nil)
       if payload

--- a/lib/nexpose/scan.rb
+++ b/lib/nexpose/scan.rb
@@ -396,7 +396,7 @@ module Nexpose
           data.map(&ActiveScan.method(:parse_json))
         end
       else
-        uri  = '/data/site/scans/dyntable.xml?printDocType=0&tableID=siteScansTable&activeOnly=true'
+        uri  = '/data/site/scans/dyntable?printDocType=0&tableID=siteScansTable&activeOnly=true'
         data = DataTable._get_dyn_table(self, uri).select { |scan| (scan['Status'].include? 'Paused') }
         data.map(&ActiveScan.method(:parse_dyntable))
       end

--- a/lib/nexpose/vuln.rb
+++ b/lib/nexpose/vuln.rb
@@ -35,7 +35,7 @@ module Nexpose
     # @return [Array[String]] Array of currently valid check categories.
     #
     def list_vuln_categories
-      data = DataTable._get_dyn_table(self, '/data/vulnerability/categories/dyntable.xml?tableID=VulnCategorySynopsis')
+      data = DataTable._get_dyn_table(self, '/data/vulnerability/categories/dyntable?tableID=VulnCategorySynopsis')
       data.map { |c| c['Category'] }
     end
 
@@ -46,7 +46,7 @@ module Nexpose
     # @return [Array[String]] Array of currently valid check types.
     #
     def vuln_types
-      data = DataTable._get_dyn_table(self, '/data/vulnerability/checktypes/dyntable.xml?tableID=VulnCheckCategorySynopsis')
+      data = DataTable._get_dyn_table(self, '/data/vulnerability/checktypes/dyntable?tableID=VulnCheckCategorySynopsis')
       data.map { |c| c['Category'] }
     end
     alias list_vuln_types vuln_types
@@ -74,7 +74,7 @@ module Nexpose
     # @return [Array[VulnCheck]] List of matching Vulnerability Checks.
     #
     def find_vuln_check(search_term, partial_words = true, all_words = true)
-      uri = "/data/vulnerability/vulnerabilities/dyntable.xml?tableID=VulnCheckSynopsis&phrase=#{URI.encode(search_term)}&allWords=#{all_words}"
+      uri = "/data/vulnerability/vulnerabilities/dyntable?tableID=VulnCheckSynopsis&phrase=#{URI.encode(search_term)}&allWords=#{all_words}"
       data = DataTable._get_dyn_table(self, uri)
       data.map do |vuln|
         XML::VulnCheck.new(vuln)
@@ -91,7 +91,7 @@ module Nexpose
     #   Nexpose between the provided dates.
     #
     def find_vulns_by_date(from, to = nil)
-      uri = "/data/vulnerability/synopsis/dyntable.xml?addedMin=#{from}"
+      uri = "/data/vulnerability/synopsis/dyntable?addedMin=#{from}"
       uri += "&addedMax=#{to}" if to
       DataTable._get_dyn_table(self, uri).map { |v| VulnSynopsis.new(v) }
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- spring 5 upgrade no longer permits .xml on the dyntable endpoints, only /dyntable used by ui (not /dyntable.xml)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
<!--- Drag-and-drop any relevant screenshots here, if applicable. -->


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
