### PR TITLE
Remove mapping for publishedDate

### DIFF
--- a/lib/nexpose/vuln.rb
+++ b/lib/nexpose/vuln.rb
@@ -153,8 +153,6 @@ module Nexpose
       attr_accessor :added
       # The last date the vulnerability was modified.
       attr_accessor :modified
-      # The date when the information about the vulnerability was first released.
-      attr_accessor :published
       # How the vulnerability is exploited according to PCI standards.
       attr_accessor :cvss_vector
       # The computation of the Common Vulnerability Scoring System indicating
@@ -173,7 +171,6 @@ module Nexpose
         vuln.credentials  = xml.attributes['requiresCredentials'] == 'true'
 
         # These three fields are optional in the XSD.
-        vuln.published    = Date.parse(xml.attributes['published']) if xml.attributes['published']
         vuln.cvss_vector  = xml.attributes['cvssVector'] if xml.attributes['cvssVector']
         vuln.cvss_score   = xml.attributes['cvssScore'].to_f if xml.attributes['cvssScore']
         vuln
@@ -240,8 +237,6 @@ module Nexpose
     attr_reader :cvss_score
     attr_reader :cvss_vector
     attr_reader :risk
-    # Date this vulnerability was published.
-    attr_reader :published
     attr_reader :severity
     # Number of instances of this vulnerabilty finding on an asset.
     attr_reader :instances
@@ -259,7 +254,6 @@ module Nexpose
       @cvss_vector = json['cvssBase']
       @cvss_score  = json['cvssScore']
       @risk        = json['riskScore']
-      @published   = Time.at(json['publishedDate'] / 1000)
       @severity    = json['severity']
       @instances   = json['vulnInstanceCount']
       @exploit     = json['mainExploit']
@@ -279,7 +273,6 @@ module Nexpose
       @cvss_vector = hash['CVSS Base Vector']
       @cvss_score  = hash['CVSS Score'].to_f
       @risk        = hash['Risk'].to_f
-      @published   = Time.at(hash['Published On'].to_i / 1000)
       @severity    = hash['Severity'].to_i
       @instances   = hash['Instances'].to_i
       @exploit     = hash['ExploitSource']


### PR DESCRIPTION
https://rapid7.atlassian.net/browse/NEX-57765

Remove mapping to publishedDate


Removal of the Published On column from the Asset vuln table has broken multiple cucumber tests

```
undefined method `/' for nil:NilClass (NoMethodError)
./features/step_definitions/site_steps.rb:334:in `/^a site with a single asset having multiple vulnerabilities$/'
features/vulnerability/exception/remove.feature:6:in `a site with a single asset having multiple vulnerabilities'
```

6.6.265


![Screenshot 2024-08-07 at 19 56 31](https://github.com/user-attachments/assets/0f0a1198-4820-49e1-becd-6161deb0b780)


6.6.264


![Screenshot 2024-08-07 at 19 56 03](https://github.com/user-attachments/assets/d86c9ec6-0048-4d7d-b1f1-91c9c886483a)

Testing

![Screenshot 2024-08-07 at 20 21 13](https://github.com/user-attachments/assets/cdbc38b3-8c4e-4872-85f3-16ecb5611248)
