### PR TITLE
fix(NEX-59797): Add console codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rapid7/console-code-owners


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
Need to ensure all changes to any nexpose related repositories have been approved by those who own the. If applied, this PR will add the @rapid7/console-code-owners team to the CODEOWNERS file inside of the .github directory.
## Testing
<!-- Describe how this change was tested -->
![Screenshot 2025-06-27 at 11 48 23](https://github.com/user-attachments/assets/896b4931-6ae9-4c14-98db-b820c91714d9)

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
